### PR TITLE
Fix 16-, 32-, and 64-bit deserialization functions

### DIFF
--- a/canadensis_encoding/src/cursor/deserialize.rs
+++ b/canadensis_encoding/src/cursor/deserialize.rs
@@ -101,7 +101,9 @@ impl<'b> ReadCursor<'b> {
             shift_bits += 8;
         }
         // Write any remaining bits that don't fill up a byte
-        value |= u64::from(self.read_up_to_u8(bits % 8)) << shift_bits;
+        if bits != 64 {
+            value |= u64::from(self.read_up_to_u8(bits % 8)) << shift_bits;
+        }
         value
     }
 
@@ -338,7 +340,7 @@ impl ReadCursor<'_> {
     }
     #[inline]
     pub fn read_u16(&mut self) -> u16 {
-        self.read_up_to_u16(16)
+        self.read_up_to_u32(16) as u16
     }
     #[inline]
     pub fn read_u17(&mut self) -> u32 {
@@ -402,7 +404,7 @@ impl ReadCursor<'_> {
     }
     #[inline]
     pub fn read_u32(&mut self) -> u32 {
-        self.read_up_to_u32(32)
+        self.read_up_to_u64(32) as u32
     }
     #[inline]
     pub fn read_u33(&mut self) -> u64 {
@@ -790,5 +792,61 @@ impl ReadCursor<'_> {
     #[inline]
     pub fn skip_64(&mut self) {
         self.advance_bits(64)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn u8_one() {
+        let bytes = [0xABu8];
+        let mut cursor = ReadCursor::new(&bytes);
+        assert_eq!(cursor.read_u8(), 0xAB);
+    }
+
+    #[test]
+    fn u16_one() {
+        let bytes = [0xCDu8, 0xAB];
+        let mut cursor = ReadCursor::new(&bytes);
+        assert_eq!(cursor.read_u16(), 0xABCD);
+    }
+
+    #[test]
+    fn u32_one() {
+        let bytes = [0xD4u8, 0xC3, 0xB2, 0xA1];
+        let mut cursor = ReadCursor::new(&bytes);
+        assert_eq!(cursor.read_u32(), 0xA1B2C3D4);
+    }
+
+    #[test]
+    fn u64_one() {
+        let bytes = [0x67u8, 0x45, 0x23, 0x01,
+                                0xD4, 0xC3, 0xB2, 0xA1];
+        let mut cursor = ReadCursor::new(&bytes);
+        assert_eq!(cursor.read_u64(), 0xA1B2C3D401234567);
+    }
+
+    #[test]
+    fn f16_one() {
+        let bytes = [0xCDu8, 0xAB];
+        let mut cursor = ReadCursor::new(&bytes);
+        assert_eq!(cursor.read_f16(), f16::from_bits(0xABCD));
+    }
+
+    #[test]
+    fn f32_one() {
+        let bytes = [0xD4u8, 0xC3, 0xB2, 0xA1];
+        let mut cursor = ReadCursor::new(&bytes);
+        assert_eq!(cursor.read_f32(), f32::from_bits(0xA1B2C3D4));
+    }
+
+    #[test]
+    fn f64_one() {
+        let bytes = [0x67u8, 0x45, 0x23, 0x01,
+                                0xD4, 0xC3, 0xB2, 0xA1];
+        let mut cursor = ReadCursor::new(&bytes);
+        assert_eq!(cursor.read_f64(), f64::from_bits(0xA1B2C3D401234567));
     }
 }


### PR DESCRIPTION
Currently, the `read_u16` function will only read 8 bits, as the second byte read operation will read `16 % 8` (`0`) bits. The `read_u32` and `read_u64` functions will attempt to shift by 32 and 64 bits respectively, leading to an error (shift leading to overflow). The functions for reading floats of these sizes (`read_f16`, `read_f32`, and `read_f64`) rely on the respective unsigned read functions, and thus are also affected.

These changes fix the issues mentioned above and also provide tests to verify the functionality being changed.

Thank you for your work in creating this library!