### PR TITLE
CAN Loopback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `canadensis`: Added loopback publishing/requesting functions and loopback handler function
 - `canadensis_bxcan`: Added support for loopback frames, with timestamps based on the transmit time calculated by
   software
-- `canadensis_can`: Added support for loopback frames and transfers
+- `canadensis_can`: Breaking change: Added support for loopback frames and transfers
 - `canadensis_core`: Added `remove` function to `SessionTracker` (Breaking change)
 - `canadensis_core`: Added `loopback` field to transfer types (Breaking change)
 - `canadensis_codegen_rust`: Added the ability to produce documentation comments in generated code based on DSDL
@@ -29,13 +29,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `canadensis`: Clippy fixes
 - `canadensis`: Breaking change: Updated `half` dependency to 2.2
 - `canadensis`: Updated private dependencies
+- `canadensis`: Breaking change: Moved clock down into drivers to make frame timestamps more accurate
 - `canadensis_bxcan`: Clippy fixes
 - `canadensis_bxcan`: Breaking change: Removed deprecated functions `bxcan_frame_to_uavcan` and `uavcan_frame_to_bxcan`,
   made the replacement functions private
 - `canadensis_bxcan`: Breaking change: Updated `bxcan` dependency to 0.7
+- `canadensis_bxcan`: Breaking change: Moved clock down into drivers to make frame timestamps more accurate
+- `canadensis_can`: Breaking change: Moved clock down into drivers to make frame timestamps more accurate
 - `canadensis_codegen_rust`: Clippy fixes
 - `canadensis_codegen_rust`: Updated `clap` dependency to 4.1
 - `canadensis_codegen_rust`: Breaking change: Updated dependencies of generated code: `half` to 2.2, `memoffset` to 0.8
+- `canadensis_core`: Breaking change: Moved clock down into drivers to make frame timestamps more accurate
 - `canadensis_data_types`: Changed the order of constants to match the order in the DSDL files
 - `canadensis_data_types`: Regenerated code to match revision 935973babe11755d8070e67452b3508b4b6833e2
   of <https://github.com/OpenCyphal/public_regulated_data_types/>
@@ -50,16 +54,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `canadensis_dsdl_frontend`: Breaking change: Updated `half` dependency to 2.2
 - `canadensis_encoding`: Clippy fixes
 - `canadensis_encoding`: Breaking change: Updated `half` dependency to 2.2
+- `canadensis_linux`: Breaking change: Moved clock down into drivers to make frame timestamps more accurate
 - `canadensis_macro`: Code generation can fail with an error
 - `canadensis_macro`: Updated `syn` dependency to 2.0
 - `canadensis_macro`: Breaking change: Updated dependencies of generated code: `half` to 2.2, `memoffset` to 0.8
 - `canadensis_pnp_client`: Updated `crc-any` dependency to 2.4
+- `canadensis_pnp_client`: Breaking change: Moved clock down into drivers to make frame timestamps more accurate
 - `canadensis_serial`: Breaking change: Changed header format
 - `canadensis_serial`: Updated `simplelog` dependency to 0.12
+- `canadensis_serial`: Breaking change: Moved clock down into drivers to make frame timestamps more accurate
 - `canadensis_udp`: Major rework for [new version of Cyphal/UDP](https://forum.opencyphal.org/t/cyphal-udp-architectural-issues-caused-by-the-dependency-between-the-nodes-ip-address-and-its-identity/1765/60)
 - `canadensis_udp`: Breaking change: Changed header format
 - `canadensis_udp`: Clippy fixes
 - `canadensis_udp`: Updated `simplelog` dependency to 0.12
+- `canadensis_udp`: Breaking change: Moved clock down into drivers to make frame timestamps more accurate
 - `canadensis_write_crc`: Updated `object` dependency to 0.30
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `canadensis`: Added loopback publishing/requesting functions and loopback handler function
+- `canadensis_bxcan`: Added support for loopback frames, with timestamps based on the transmit time calculated by
+  software
+- `canadensis_can`: Added support for loopback frames and transfers
 - `canadensis_core`: Added `remove` function to `SessionTracker` (Breaking change)
+- `canadensis_core`: Added `loopback` field to transfer types (Breaking change)
 - `canadensis_codegen_rust`: Added the ability to produce documentation comments in generated code based on DSDL
   comments
 - `canadensis_codegen_rust`: Added the ability to generate enums from DSDL types marked with `#[canadensis(enum)]`

--- a/canadensis/examples/basic_node.rs
+++ b/canadensis/examples/basic_node.rs
@@ -110,7 +110,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let core_node: CoreNode<
         SystemClock,
-        CanTransmitter<Microseconds64, Queue>,
+        CanTransmitter<SystemClock, Queue>,
         CanReceiver<Microseconds64, Queue>,
         TransferIdFixedMap<CanTransport, TRANSFER_IDS>,
         Queue,

--- a/canadensis/examples/basic_node.rs
+++ b/canadensis/examples/basic_node.rs
@@ -97,7 +97,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     const QUEUE_CAPACITY: usize = 1210;
-    type Queue = SingleQueueDriver<ArrayQueue<Microseconds64, QUEUE_CAPACITY>, LinuxCan>;
+    type Queue =
+        SingleQueueDriver<SystemClock, ArrayQueue<Microseconds64, QUEUE_CAPACITY>, LinuxCan>;
     let queue_driver: Queue = SingleQueueDriver::new(ArrayQueue::new(), can);
 
     // Create a node with capacity for 8 publishers and 8 requesters
@@ -111,7 +112,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let core_node: CoreNode<
         SystemClock,
         CanTransmitter<SystemClock, Queue>,
-        CanReceiver<Microseconds64, Queue>,
+        CanReceiver<SystemClock, Queue>,
         TransferIdFixedMap<CanTransport, TRANSFER_IDS>,
         Queue,
         PUBLISHERS,

--- a/canadensis/examples/minimal_node.rs
+++ b/canadensis/examples/minimal_node.rs
@@ -68,7 +68,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     const REQUESTERS: usize = 2;
     let core_node: CoreNode<
         SystemClock,
-        CanTransmitter<Microseconds64, LinuxCan>,
+        CanTransmitter<SystemClock, LinuxCan>,
         CanReceiver<Microseconds64, LinuxCan>,
         TransferIdFixedMap<CanTransport, TRANSFER_IDS>,
         LinuxCan,

--- a/canadensis/examples/minimal_node.rs
+++ b/canadensis/examples/minimal_node.rs
@@ -36,7 +36,6 @@ use std::time::Duration;
 
 use socketcan::CANSocket;
 
-use canadensis::core::time::Microseconds64;
 use canadensis::node::{CoreNode, MinimalNode};
 use canadensis::requester::TransferIdFixedMap;
 use canadensis::Node;
@@ -69,7 +68,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let core_node: CoreNode<
         SystemClock,
         CanTransmitter<SystemClock, LinuxCan>,
-        CanReceiver<Microseconds64, LinuxCan>,
+        CanReceiver<SystemClock, LinuxCan>,
         TransferIdFixedMap<CanTransport, TRANSFER_IDS>,
         LinuxCan,
         PUBLISHERS,

--- a/canadensis/examples/register_client.rs
+++ b/canadensis/examples/register_client.rs
@@ -95,7 +95,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     // Create a node with capacity for 2 publishers and 2 requesters
-    type Queue = SingleQueueDriver<ArrayQueue<Microseconds64, 64>, LinuxCan>;
+    type Queue = SingleQueueDriver<SystemClock, ArrayQueue<Microseconds64, 64>, LinuxCan>;
     // TRANSFER_IDS must be a power of two and greater than one
     const TRANSFER_IDS: usize = 2;
     const PUBLISHERS: usize = 2;
@@ -107,7 +107,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let core_node: CoreNode<
         SystemClock,
         CanTransmitter<SystemClock, Queue>,
-        CanReceiver<Microseconds64, Queue>,
+        CanReceiver<SystemClock, Queue>,
         TransferIdFixedMap<CanTransport, TRANSFER_IDS>,
         Queue,
         PUBLISHERS,

--- a/canadensis/examples/register_client.rs
+++ b/canadensis/examples/register_client.rs
@@ -106,7 +106,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let receiver = CanReceiver::new(node_id, Mtu::Can8);
     let core_node: CoreNode<
         SystemClock,
-        CanTransmitter<Microseconds64, Queue>,
+        CanTransmitter<SystemClock, Queue>,
         CanReceiver<Microseconds64, Queue>,
         TransferIdFixedMap<CanTransport, TRANSFER_IDS>,
         Queue,

--- a/canadensis/examples/registers.rs
+++ b/canadensis/examples/registers.rs
@@ -95,7 +95,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     // Create a node with capacity for 82 publishers and 2 requesters
-    type Queue = SingleQueueDriver<ArrayQueue<Microseconds64, 64>, LinuxCan>;
+    type Queue = SingleQueueDriver<SystemClock, ArrayQueue<Microseconds64, 64>, LinuxCan>;
     const TRANSFER_IDS: usize = 1;
     const PUBLISHERS: usize = 2;
     const REQUESTERS: usize = 2;
@@ -106,7 +106,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let core_node: CoreNode<
         SystemClock,
         CanTransmitter<SystemClock, Queue>,
-        CanReceiver<Microseconds64, Queue>,
+        CanReceiver<SystemClock, Queue>,
         TransferIdFixedMap<CanTransport, TRANSFER_IDS>,
         Queue,
         PUBLISHERS,

--- a/canadensis/examples/registers.rs
+++ b/canadensis/examples/registers.rs
@@ -105,7 +105,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let receiver = CanReceiver::new(node_id, Mtu::Can8);
     let core_node: CoreNode<
         SystemClock,
-        CanTransmitter<Microseconds64, Queue>,
+        CanTransmitter<SystemClock, Queue>,
         CanReceiver<Microseconds64, Queue>,
         TransferIdFixedMap<CanTransport, TRANSFER_IDS>,
         Queue,

--- a/canadensis/examples/tcp_serial_basic_node.rs
+++ b/canadensis/examples/tcp_serial_basic_node.rs
@@ -94,7 +94,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         SystemClock,
         SerialTransmitter<SocketDriver, 256>,
         SerialReceiver<
-            Microseconds64,
+            SystemClock,
             SocketDriver,
             DynamicSubscriptionManager<Subscription<Microseconds64>>,
         >,

--- a/canadensis/examples/udp_basic_node.rs
+++ b/canadensis/examples/udp_basic_node.rs
@@ -84,7 +84,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         SystemClock,
         UdpTransmitter<StdUdpSocket, MTU>,
         UdpReceiver<
-            Microseconds64,
+            SystemClock,
             SessionDynamicMap<Microseconds64, UdpNodeId, UdpTransferId, UdpSessionData>,
             StdUdpSocket,
             MTU,

--- a/canadensis/src/anonymous.rs
+++ b/canadensis/src/anonymous.rs
@@ -17,7 +17,7 @@ use canadensis_encoding::{Message, Serialize};
 /// Anonymous nodes have some limitations:
 /// * They can only send messages, not service requests or responses
 /// * They cannot send multi-frame messages
-pub struct AnonymousPublisher<C: Clock, M, T: Transmitter<C::Instant>> {
+pub struct AnonymousPublisher<C: Clock, M, T: Transmitter<C>> {
     /// The priority of transfers from this transmitter
     priority: <T::Transport as Transport>::Priority,
     /// The subject to transmit on
@@ -34,7 +34,7 @@ impl<C, M, T> AnonymousPublisher<C, M, T>
 where
     C: Clock,
     M: Message + Serialize,
-    T: Transmitter<C::Instant>,
+    T: Transmitter<C>,
 {
     /// Creates an anonymous message publisher
     pub fn new(

--- a/canadensis/src/lib.rs
+++ b/canadensis/src/lib.rs
@@ -328,7 +328,7 @@ pub trait Node {
     /// The transport that this node uses
     type Transport: Transport;
     /// The transmitter that this node uses
-    type Transmitter: Transmitter<Self::Instant, Transport = Self::Transport>;
+    type Transmitter: Transmitter<Self::Clock, Transport = Self::Transport>;
     /// The receiver that this node uses
     type Receiver: Receiver<Self::Instant, Transport = Self::Transport>;
 
@@ -360,7 +360,7 @@ pub trait Node {
         priority: <Self::Transport as Transport>::Priority,
     ) -> Result<
         PublishToken<T>,
-        StartSendError<<Self::Transmitter as Transmitter<Self::Instant>>::Error>,
+        StartSendError<<Self::Transmitter as Transmitter<Self::Clock>>::Error>,
     >
     where
         T: Message;
@@ -377,7 +377,7 @@ pub trait Node {
         &mut self,
         token: &PublishToken<T>,
         payload: &T,
-    ) -> nb::Result<(), <Self::Transmitter as Transmitter<Self::Instant>>::Error>
+    ) -> nb::Result<(), <Self::Transmitter as Transmitter<Self::Clock>>::Error>
     where
         T: Message + Serialize;
 
@@ -388,7 +388,7 @@ pub trait Node {
         &mut self,
         token: &PublishToken<T>,
         payload: &T,
-    ) -> nb::Result<(), <Self::Transmitter as Transmitter<Self::Instant>>::Error>
+    ) -> nb::Result<(), <Self::Transmitter as Transmitter<Self::Clock>>::Error>
     where
         T: Message + Serialize;
 
@@ -423,7 +423,7 @@ pub trait Node {
         destination: <Self::Transport as Transport>::NodeId,
     ) -> nb::Result<
         <Self::Transport as Transport>::TransferId,
-        <Self::Transmitter as Transmitter<Self::Instant>>::Error,
+        <Self::Transmitter as Transmitter<Self::Clock>>::Error,
     >
     where
         T: Request + Serialize;
@@ -438,7 +438,7 @@ pub trait Node {
         destination: <Self::Transport as Transport>::NodeId,
     ) -> nb::Result<
         <Self::Transport as Transport>::TransferId,
-        <Self::Transmitter as Transmitter<Self::Instant>>::Error,
+        <Self::Transmitter as Transmitter<Self::Clock>>::Error,
     >
     where
         T: Request + Serialize;
@@ -471,13 +471,12 @@ pub trait Node {
         token: ResponseToken<Self::Transport>,
         timeout: <<<Self as Node>::Clock as Clock>::Instant as Instant>::Duration,
         payload: &T,
-    ) -> nb::Result<(), <Self::Transmitter as Transmitter<Self::Instant>>::Error>
+    ) -> nb::Result<(), <Self::Transmitter as Transmitter<Self::Clock>>::Error>
     where
         T: Response + Serialize;
 
     /// Attempts to flush all outgoing frames
-    fn flush(&mut self)
-        -> nb::Result<(), <Self::Transmitter as Transmitter<Self::Instant>>::Error>;
+    fn flush(&mut self) -> nb::Result<(), <Self::Transmitter as Transmitter<Self::Clock>>::Error>;
 
     // Component access
 

--- a/canadensis/src/lib.rs
+++ b/canadensis/src/lib.rs
@@ -330,7 +330,7 @@ pub trait Node {
     /// The transmitter that this node uses
     type Transmitter: Transmitter<Self::Clock, Transport = Self::Transport>;
     /// The receiver that this node uses
-    type Receiver: Receiver<Self::Instant, Transport = Self::Transport>;
+    type Receiver: Receiver<Self::Clock, Transport = Self::Transport>;
 
     /// Receives any available incoming frames and attempts ot reassemble them into a transfer
     ///
@@ -342,7 +342,7 @@ pub trait Node {
     fn receive<H>(
         &mut self,
         handler: &mut H,
-    ) -> Result<(), <Self::Receiver as Receiver<Self::Instant>>::Error>
+    ) -> Result<(), <Self::Receiver as Receiver<Self::Clock>>::Error>
     where
         H: TransferHandler<Self::Instant, Self::Transport>;
 
@@ -404,7 +404,7 @@ pub trait Node {
         receive_timeout: <<<Self as Node>::Clock as Clock>::Instant as Instant>::Duration,
         response_payload_size_max: usize,
         priority: <Self::Transport as Transport>::Priority,
-    ) -> Result<ServiceToken<T>, StartSendError<<Self::Receiver as Receiver<Self::Instant>>::Error>>
+    ) -> Result<ServiceToken<T>, StartSendError<<Self::Receiver as Receiver<Self::Clock>>::Error>>
     where
         T: Request;
 
@@ -449,7 +449,7 @@ pub trait Node {
         subject: SubjectId,
         payload_size_max: usize,
         timeout: <<<Self as Node>::Clock as Clock>::Instant as Instant>::Duration,
-    ) -> Result<(), <Self::Receiver as Receiver<Self::Instant>>::Error>;
+    ) -> Result<(), <Self::Receiver as Receiver<Self::Clock>>::Error>;
 
     /// Subscribes to requests for a service
     fn subscribe_request(
@@ -457,7 +457,7 @@ pub trait Node {
         service: ServiceId,
         payload_size_max: usize,
         timeout: <<<Self as Node>::Clock as Clock>::Instant as Instant>::Duration,
-    ) -> Result<(), <Self::Receiver as Receiver<Self::Instant>>::Error>;
+    ) -> Result<(), <Self::Receiver as Receiver<Self::Clock>>::Error>;
 
     /// Responds to a service request
     ///

--- a/canadensis/src/lib.rs
+++ b/canadensis/src/lib.rs
@@ -150,10 +150,9 @@ pub trait TransferHandler<I: Instant, T: Transport> {
     /// The default implementation does nothing and returns false.
     fn handle_loopback<N: Node<Instant = I, Transport = T>>(
         &mut self,
-        node: &mut N,
-        transfer: &Transfer<Vec<u8>, I, T>,
+        _node: &mut N,
+        _transfer: &Transfer<Vec<u8>, I, T>,
     ) -> bool {
-        drop((node, transfer));
         false
     }
 

--- a/canadensis/src/node/basic.rs
+++ b/canadensis/src/node/basic.rs
@@ -53,7 +53,7 @@ where
     ) -> Result<
         Self,
         NodeError<
-            StartSendError<<N::Transmitter as Transmitter<N::Instant>>::Error>,
+            StartSendError<<N::Transmitter as Transmitter<N::Clock>>::Error>,
             <N::Receiver as Receiver<N::Instant>>::Error,
         >,
     > {
@@ -113,7 +113,7 @@ where
     /// This function must be called once per second to send heartbeat and port list messages
     pub fn run_per_second_tasks(
         &mut self,
-    ) -> nb::Result<(), <N::Transmitter as Transmitter<N::Instant>>::Error> {
+    ) -> nb::Result<(), <N::Transmitter as Transmitter<N::Clock>>::Error> {
         self.node.run_per_second_tasks()?;
         if self.seconds_since_port_list_published == 10 {
             self.seconds_since_port_list_published = 1;
@@ -126,7 +126,7 @@ where
 
     fn publish_port_list(
         &mut self,
-    ) -> nb::Result<(), <N::Transmitter as Transmitter<N::Instant>>::Error> {
+    ) -> nb::Result<(), <N::Transmitter as Transmitter<N::Clock>>::Error> {
         self.node
             .node_mut()
             .publish(&self.port_list_token, &self.port_list)
@@ -184,7 +184,7 @@ where
         subject: SubjectId,
         timeout: <<N::Clock as Clock>::Instant as Instant>::Duration,
         priority: <Self::Transport as Transport>::Priority,
-    ) -> Result<PublishToken<T>, StartSendError<<N::Transmitter as Transmitter<N::Instant>>::Error>>
+    ) -> Result<PublishToken<T>, StartSendError<<N::Transmitter as Transmitter<N::Clock>>::Error>>
     where
         T: Message,
     {
@@ -210,7 +210,7 @@ where
         &mut self,
         token: &PublishToken<T>,
         payload: &T,
-    ) -> nb::Result<(), <N::Transmitter as Transmitter<N::Instant>>::Error>
+    ) -> nb::Result<(), <N::Transmitter as Transmitter<N::Clock>>::Error>
     where
         T: Message + Serialize,
     {
@@ -221,7 +221,7 @@ where
         &mut self,
         token: &PublishToken<T>,
         payload: &T,
-    ) -> nb::Result<(), <Self::Transmitter as Transmitter<Self::Instant>>::Error>
+    ) -> nb::Result<(), <Self::Transmitter as Transmitter<Self::Clock>>::Error>
     where
         T: Message + Serialize,
     {
@@ -266,7 +266,7 @@ where
         destination: <Self::Transport as Transport>::NodeId,
     ) -> nb::Result<
         <Self::Transport as Transport>::TransferId,
-        <N::Transmitter as Transmitter<N::Instant>>::Error,
+        <N::Transmitter as Transmitter<N::Clock>>::Error,
     >
     where
         T: Request + Serialize,
@@ -283,7 +283,7 @@ where
         destination: <Self::Transport as Transport>::NodeId,
     ) -> nb::Result<
         <Self::Transport as Transport>::TransferId,
-        <Self::Transmitter as Transmitter<Self::Instant>>::Error,
+        <Self::Transmitter as Transmitter<Self::Clock>>::Error,
     >
     where
         T: Request + Serialize,
@@ -330,7 +330,7 @@ where
         token: ResponseToken<Self::Transport>,
         timeout: <<N::Clock as Clock>::Instant as Instant>::Duration,
         payload: &T,
-    ) -> nb::Result<(), <N::Transmitter as Transmitter<N::Instant>>::Error>
+    ) -> nb::Result<(), <N::Transmitter as Transmitter<N::Clock>>::Error>
     where
         T: Response + Serialize,
     {
@@ -339,7 +339,7 @@ where
 
     fn flush(
         &mut self,
-    ) -> canadensis_core::nb::Result<(), <N::Transmitter as Transmitter<N::Instant>>::Error> {
+    ) -> canadensis_core::nb::Result<(), <N::Transmitter as Transmitter<N::Clock>>::Error> {
         self.node.node_mut().flush()
     }
 

--- a/canadensis/src/node/basic.rs
+++ b/canadensis/src/node/basic.rs
@@ -217,6 +217,17 @@ where
         self.node.node_mut().publish(token, payload)
     }
 
+    fn publish_loopback<T>(
+        &mut self,
+        token: &PublishToken<T>,
+        payload: &T,
+    ) -> nb::Result<(), <Self::Transmitter as Transmitter<Self::Instant>>::Error>
+    where
+        T: Message + Serialize,
+    {
+        self.node.node_mut().publish_loopback(token, payload)
+    }
+
     fn start_sending_requests<T>(
         &mut self,
         service: ServiceId,
@@ -263,6 +274,23 @@ where
         self.node
             .node_mut()
             .send_request(token, payload, destination)
+    }
+
+    fn send_request_loopback<T>(
+        &mut self,
+        token: &ServiceToken<T>,
+        payload: &T,
+        destination: <Self::Transport as Transport>::NodeId,
+    ) -> nb::Result<
+        <Self::Transport as Transport>::TransferId,
+        <Self::Transmitter as Transmitter<Self::Instant>>::Error,
+    >
+    where
+        T: Request + Serialize,
+    {
+        self.node
+            .node_mut()
+            .send_request_loopback(token, payload, destination)
     }
 
     fn subscribe_message(

--- a/canadensis/src/node/basic.rs
+++ b/canadensis/src/node/basic.rs
@@ -54,7 +54,7 @@ where
         Self,
         NodeError<
             StartSendError<<N::Transmitter as Transmitter<N::Clock>>::Error>,
-            <N::Receiver as Receiver<N::Instant>>::Error,
+            <N::Receiver as Receiver<N::Clock>>::Error,
         >,
     > {
         // The MinimalNode takes care of heartbeats.
@@ -168,7 +168,7 @@ where
     fn receive<H>(
         &mut self,
         handler: &mut H,
-    ) -> Result<(), <N::Receiver as Receiver<N::Instant>>::Error>
+    ) -> Result<(), <N::Receiver as Receiver<N::Clock>>::Error>
     where
         H: TransferHandler<Self::Instant, Self::Transport>,
     {
@@ -234,7 +234,7 @@ where
         receive_timeout: <<N::Clock as Clock>::Instant as Instant>::Duration,
         response_payload_size_max: usize,
         priority: <Self::Transport as Transport>::Priority,
-    ) -> Result<ServiceToken<T>, StartSendError<<N::Receiver as Receiver<N::Instant>>::Error>>
+    ) -> Result<ServiceToken<T>, StartSendError<<N::Receiver as Receiver<N::Clock>>::Error>>
     where
         T: Request,
     {
@@ -298,7 +298,7 @@ where
         subject: SubjectId,
         payload_size_max: usize,
         timeout: <<N::Clock as Clock>::Instant as Instant>::Duration,
-    ) -> Result<(), <N::Receiver as Receiver<N::Instant>>::Error> {
+    ) -> Result<(), <N::Receiver as Receiver<N::Clock>>::Error> {
         self.node
             .node_mut()
             .subscribe_message(subject, payload_size_max, timeout)?;
@@ -314,7 +314,7 @@ where
         service: ServiceId,
         payload_size_max: usize,
         timeout: <<N::Clock as Clock>::Instant as Instant>::Duration,
-    ) -> Result<(), <N::Receiver as Receiver<N::Instant>>::Error> {
+    ) -> Result<(), <N::Receiver as Receiver<N::Clock>>::Error> {
         self.node
             .node_mut()
             .subscribe_request(service, payload_size_max, timeout)?;

--- a/canadensis/src/node/core.rs
+++ b/canadensis/src/node/core.rs
@@ -34,7 +34,7 @@ use crate::{Node, PublishToken, ResponseToken, ServiceToken, StartSendError, Tra
 pub struct CoreNode<C, T, U, TR, D, const P: usize, const R: usize>
 where
     C: Clock,
-    U: Receiver<C::Instant>,
+    U: Receiver<C>,
     T: Transmitter<C>,
 {
     clock: C,
@@ -50,7 +50,7 @@ impl<C, T, U, N, TR, D, const P: usize, const R: usize> CoreNode<C, T, U, TR, D,
 where
     C: Clock,
     N: Transport,
-    U: Receiver<C::Instant, Transport = N, Driver = D>,
+    U: Receiver<C, Transport = N, Driver = D>,
     T: Transmitter<C, Transport = N, Driver = D>,
     TR: TransferIdTracker<N>,
 {
@@ -163,7 +163,7 @@ where
     C: Clock,
     N: Transport,
     T: Transmitter<C, Transport = N, Driver = D>,
-    U: Receiver<<C as Clock>::Instant, Transport = N, Driver = D>,
+    U: Receiver<C, Transport = N, Driver = D>,
     TR: TransferIdTracker<N>,
 {
     type Clock = C;
@@ -176,7 +176,7 @@ where
     where
         H: TransferHandler<Self::Instant, Self::Transport>,
     {
-        if let Some(transfer) = self.receiver.receive(self.clock.now(), &mut self.driver)? {
+        if let Some(transfer) = self.receiver.receive(&mut self.clock, &mut self.driver)? {
             self.handle_incoming_transfer(transfer, handler)
         }
         Ok(())

--- a/canadensis/src/node/core.rs
+++ b/canadensis/src/node/core.rs
@@ -35,15 +35,15 @@ pub struct CoreNode<C, T, U, TR, D, const P: usize, const R: usize>
 where
     C: Clock,
     U: Receiver<C::Instant>,
-    T: Transmitter<C::Instant>,
+    T: Transmitter<C>,
 {
     clock: C,
     transmitter: T,
     receiver: U,
     driver: D,
     node_id: <T::Transport as Transport>::NodeId,
-    publishers: FnvIndexMap<SubjectId, Publisher<C::Instant, T>, P>,
-    requesters: FnvIndexMap<ServiceId, Requester<C::Instant, T, TR>, R>,
+    publishers: FnvIndexMap<SubjectId, Publisher<C, T>, P>,
+    requesters: FnvIndexMap<ServiceId, Requester<C, T, TR>, R>,
 }
 
 impl<C, T, U, N, TR, D, const P: usize, const R: usize> CoreNode<C, T, U, TR, D, P, R>
@@ -51,7 +51,7 @@ where
     C: Clock,
     N: Transport,
     U: Receiver<C::Instant, Transport = N, Driver = D>,
-    T: Transmitter<C::Instant, Transport = N, Driver = D>,
+    T: Transmitter<C, Transport = N, Driver = D>,
     TR: TransferIdTracker<N>,
 {
     /// Creates a node
@@ -162,7 +162,7 @@ impl<C, T, U, N, TR, D, const P: usize, const R: usize> Node for CoreNode<C, T, 
 where
     C: Clock,
     N: Transport,
-    T: Transmitter<<C as Clock>::Instant, Transport = N, Driver = D>,
+    T: Transmitter<C, Transport = N, Driver = D>,
     U: Receiver<<C as Clock>::Instant, Transport = N, Driver = D>,
     TR: TransferIdTracker<N>,
 {
@@ -332,7 +332,7 @@ where
         destination: <Self::Transport as Transport>::NodeId,
     ) -> nb::Result<
         <Self::Transport as Transport>::TransferId,
-        <Self::Transmitter as Transmitter<Self::Instant>>::Error,
+        <Self::Transmitter as Transmitter<Self::Clock>>::Error,
     >
     where
         M: Request + Serialize,

--- a/canadensis/src/node/minimal.rs
+++ b/canadensis/src/node/minimal.rs
@@ -36,7 +36,7 @@ where
     /// * `node`: The underlying node (this is usually a [`CoreNode`](crate::node::CoreNode))
     pub fn new(
         mut node: N,
-    ) -> Result<Self, StartSendError<<N::Transmitter as Transmitter<N::Instant>>::Error>> {
+    ) -> Result<Self, StartSendError<<N::Transmitter as Transmitter<N::Clock>>::Error>> {
         // Default heartbeat settings
         let heartbeat = Heartbeat {
             uptime: 0,
@@ -73,14 +73,14 @@ where
     /// Either `run_periodic_tasks` or `run_per_second_tasks` should be called, but not both.
     pub fn run_per_second_tasks(
         &mut self,
-    ) -> nb::Result<(), <N::Transmitter as Transmitter<N::Instant>>::Error> {
+    ) -> nb::Result<(), <N::Transmitter as Transmitter<N::Clock>>::Error> {
         self.send_heartbeat()
     }
 
     /// Publishes a heartbeat message
     fn send_heartbeat(
         &mut self,
-    ) -> nb::Result<(), <N::Transmitter as Transmitter<N::Instant>>::Error> {
+    ) -> nb::Result<(), <N::Transmitter as Transmitter<N::Clock>>::Error> {
         self.heartbeat.uptime = self.heartbeat.uptime.saturating_add(1);
         self.node.publish(&self.heartbeat_token, &self.heartbeat)
     }

--- a/canadensis/src/register.rs
+++ b/canadensis/src/register.rs
@@ -139,7 +139,7 @@ where
     /// for requests.
     pub fn subscribe_requests<N>(
         node: &mut N,
-    ) -> Result<(), <N::Receiver as Receiver<N::Instant>>::Error>
+    ) -> Result<(), <N::Receiver as Receiver<N::Clock>>::Error>
     where
         N: Node,
     {

--- a/canadensis/tests/can_loopback.rs
+++ b/canadensis/tests/can_loopback.rs
@@ -1,10 +1,9 @@
-//! Tests the Cyphal/CAN loopback behavior
+//! Tests the Cyphal/CAN loopback behavior by sending a loopback transfer and
 
 extern crate canadensis;
 extern crate canadensis_can;
 extern crate canadensis_data_types;
 extern crate canadensis_encoding;
-extern crate canadensis_linux;
 extern crate log;
 extern crate simplelog;
 
@@ -14,14 +13,14 @@ use canadensis::{Node, PublishToken, ResponseToken, TransferHandler};
 use canadensis_can::driver::{ReceiveDriver, TransmitDriver};
 use canadensis_can::{CanNodeId, CanReceiver, CanTransmitter, CanTransport, Frame, Mtu};
 use canadensis_core::subscription::Subscription;
-use canadensis_core::time::{milliseconds, Microseconds64};
+use canadensis_core::time::{milliseconds, Clock, Microseconds64};
 use canadensis_core::transfer::{MessageTransfer, ServiceTransfer, Transfer};
 use canadensis_core::{OutOfMemoryError, Priority};
 use canadensis_data_types::uavcan::time::synchronization_1_0::{self, Synchronization};
 use canadensis_encoding::Deserialize;
-use canadensis_linux::SystemClock;
 use log::LevelFilter;
 use simplelog::{ColorChoice, Config, TerminalMode};
+use std::cell::Cell;
 use std::collections::vec_deque::VecDeque;
 use std::convert::{Infallible, TryFrom};
 
@@ -35,9 +34,10 @@ fn can_loopback_time_sync() {
     )
     .unwrap();
 
+    let clock_handle = StubClockHandle::new();
     let node_id = CanNodeId::try_from(3_u8).unwrap();
     let mut node: CoreNode<
-        SystemClock,
+        StubClock<'_>,
         CanTransmitter<Microseconds64, LoopbackOnlyDriver>,
         CanReceiver<Microseconds64, LoopbackOnlyDriver>,
         TransferIdFixedMap<CanTransport, 4>,
@@ -45,7 +45,7 @@ fn can_loopback_time_sync() {
         4,
         4,
     > = CoreNode::new(
-        SystemClock::new(),
+        clock_handle.clock(),
         node_id,
         CanTransmitter::new(Mtu::Can8),
         CanReceiver::new(node_id, Mtu::Can8),
@@ -63,6 +63,7 @@ fn can_loopback_time_sync() {
             Priority::Nominal,
         )
         .unwrap();
+    clock_handle.set_time(10);
     // Send a non-loopback transfer, which should be ignored
     node.publish(
         &sync_token,
@@ -73,16 +74,24 @@ fn can_loopback_time_sync() {
     .unwrap();
 
     let mut collector = LoopbackCollector::default();
+    clock_handle.set_time(20);
     node.receive(&mut collector)
         .expect("Unexpected error in receive");
     assert_eq!(0, collector.transfers.len());
 
     // Send a loopback transfer, which should be collected
+    // Outgoing frames will have their transmit deadline (timestamp) set to 30 microseconds
+    // + 100 milliseconds.
+    // The frames will actually get to the driver at a time of 30 microseconds, so the timestamp
+    // of the received loopback transfer should match that.
+    clock_handle.set_time(30);
     let loopback_payload = Synchronization {
         previous_transmission_timestamp_microsecond: 129,
     };
     node.publish_loopback(&sync_token, &loopback_payload)
         .unwrap();
+    // Simulate a short delay before receiving
+    clock_handle.set_time(40);
     node.receive(&mut collector)
         .expect("Unexpected error in receive");
     assert_eq!(1, collector.transfers.len());
@@ -90,6 +99,10 @@ fn can_loopback_time_sync() {
     assert_eq!(received_loopback.loopback, true);
     assert_eq!(received_loopback.header.priority(), &Priority::Nominal);
     assert_eq!(received_loopback.header.source(), Some(&node_id));
+    assert_eq!(
+        received_loopback.header.timestamp(),
+        Microseconds64::new(30)
+    );
     let loopback_deserialized_payload =
         Synchronization::deserialize_from_bytes(&received_loopback.payload).unwrap();
     assert_eq!(
@@ -207,5 +220,35 @@ impl TransferHandler<Microseconds64, CanTransport> for LoopbackCollector {
     ) -> bool {
         self.transfers.push(transfer.clone());
         true
+    }
+}
+
+struct StubClock<'t> {
+    time: &'t Cell<u64>,
+}
+
+impl Clock for StubClock<'_> {
+    type Instant = Microseconds64;
+
+    fn now(&mut self) -> Self::Instant {
+        Microseconds64::new(self.time.get())
+    }
+}
+
+struct StubClockHandle {
+    time: Cell<u64>,
+}
+
+impl StubClockHandle {
+    pub fn new() -> Self {
+        StubClockHandle { time: Cell::new(0) }
+    }
+    /// Sets the time that all associated stub clocks will return
+    pub fn set_time(&self, time: u64) {
+        self.time.set(time);
+    }
+    /// Creates and returns a stub clock that always returns the same time as this handle
+    pub fn clock(&self) -> StubClock<'_> {
+        StubClock { time: &self.time }
     }
 }

--- a/canadensis/tests/can_loopback.rs
+++ b/canadensis/tests/can_loopback.rs
@@ -40,7 +40,7 @@ fn can_loopback_time_sync() {
     let mut node: CoreNode<
         StubClock<'_>,
         CanTransmitter<StubClock<'_>, LoopbackOnlyDriver>,
-        CanReceiver<Microseconds64, LoopbackOnlyDriver>,
+        CanReceiver<StubClock<'_>, LoopbackOnlyDriver>,
         TransferIdFixedMap<CanTransport, 4>,
         LoopbackOnlyDriver,
         4,
@@ -155,12 +155,12 @@ impl TransmitDriver<StubClock<'_>> for LoopbackOnlyDriver {
         Ok(())
     }
 }
-impl ReceiveDriver<Microseconds64> for LoopbackOnlyDriver {
+impl ReceiveDriver<StubClock<'_>> for LoopbackOnlyDriver {
     type Error = Infallible;
 
     fn receive(
         &mut self,
-        _now: Microseconds64,
+        _clock: &mut StubClock<'_>,
     ) -> canadensis::nb::Result<Frame<Microseconds64>, Self::Error> {
         self.loopback_frames
             .pop_front()

--- a/canadensis/tests/can_loopback.rs
+++ b/canadensis/tests/can_loopback.rs
@@ -1,0 +1,211 @@
+//! Tests the Cyphal/CAN loopback behavior
+
+extern crate canadensis;
+extern crate canadensis_can;
+extern crate canadensis_data_types;
+extern crate canadensis_encoding;
+extern crate canadensis_linux;
+extern crate log;
+extern crate simplelog;
+
+use canadensis::node::CoreNode;
+use canadensis::requester::TransferIdFixedMap;
+use canadensis::{Node, PublishToken, ResponseToken, TransferHandler};
+use canadensis_can::driver::{ReceiveDriver, TransmitDriver};
+use canadensis_can::{CanNodeId, CanReceiver, CanTransmitter, CanTransport, Frame, Mtu};
+use canadensis_core::subscription::Subscription;
+use canadensis_core::time::{milliseconds, Microseconds64};
+use canadensis_core::transfer::{MessageTransfer, ServiceTransfer, Transfer};
+use canadensis_core::{OutOfMemoryError, Priority};
+use canadensis_data_types::uavcan::time::synchronization_1_0::{self, Synchronization};
+use canadensis_encoding::Deserialize;
+use canadensis_linux::SystemClock;
+use log::LevelFilter;
+use simplelog::{ColorChoice, Config, TerminalMode};
+use std::collections::vec_deque::VecDeque;
+use std::convert::{Infallible, TryFrom};
+
+#[test]
+fn can_loopback_time_sync() {
+    simplelog::TermLogger::init(
+        LevelFilter::Trace,
+        Config::default(),
+        TerminalMode::default(),
+        ColorChoice::Auto,
+    )
+    .unwrap();
+
+    let node_id = CanNodeId::try_from(3_u8).unwrap();
+    let mut node: CoreNode<
+        SystemClock,
+        CanTransmitter<Microseconds64, LoopbackOnlyDriver>,
+        CanReceiver<Microseconds64, LoopbackOnlyDriver>,
+        TransferIdFixedMap<CanTransport, 4>,
+        LoopbackOnlyDriver,
+        4,
+        4,
+    > = CoreNode::new(
+        SystemClock::new(),
+        node_id,
+        CanTransmitter::new(Mtu::Can8),
+        CanReceiver::new(node_id, Mtu::Can8),
+        LoopbackOnlyDriver::default(),
+    );
+
+    // Need to subscribe to receive loopback transfers
+    node.subscribe_message(synchronization_1_0::SUBJECT, 8, milliseconds(100))
+        .unwrap();
+
+    let sync_token: PublishToken<Synchronization> = node
+        .start_publishing(
+            synchronization_1_0::SUBJECT,
+            milliseconds(100),
+            Priority::Nominal,
+        )
+        .unwrap();
+    // Send a non-loopback transfer, which should be ignored
+    node.publish(
+        &sync_token,
+        &Synchronization {
+            previous_transmission_timestamp_microsecond: 3,
+        },
+    )
+    .unwrap();
+
+    let mut collector = LoopbackCollector::default();
+    node.receive(&mut collector)
+        .expect("Unexpected error in receive");
+    assert_eq!(0, collector.transfers.len());
+
+    // Send a loopback transfer, which should be collected
+    let loopback_payload = Synchronization {
+        previous_transmission_timestamp_microsecond: 129,
+    };
+    node.publish_loopback(&sync_token, &loopback_payload)
+        .unwrap();
+    node.receive(&mut collector)
+        .expect("Unexpected error in receive");
+    assert_eq!(1, collector.transfers.len());
+    let received_loopback = &collector.transfers[0];
+    assert_eq!(received_loopback.loopback, true);
+    assert_eq!(received_loopback.header.priority(), &Priority::Nominal);
+    assert_eq!(received_loopback.header.source(), Some(&node_id));
+    let loopback_deserialized_payload =
+        Synchronization::deserialize_from_bytes(&received_loopback.payload).unwrap();
+    assert_eq!(
+        loopback_deserialized_payload.previous_transmission_timestamp_microsecond,
+        loopback_payload.previous_transmission_timestamp_microsecond
+    );
+}
+
+/// A CAN driver that handles loopback only
+///
+/// This driver discards all outgoing non-loopback frames and cannot receive any non-loopback
+/// frames.
+#[derive(Default)]
+struct LoopbackOnlyDriver {
+    loopback_frames: VecDeque<Frame<Microseconds64>>,
+}
+
+impl TransmitDriver<Microseconds64> for LoopbackOnlyDriver {
+    type Error = Infallible;
+
+    fn try_reserve(&mut self, _frames: usize) -> Result<(), OutOfMemoryError> {
+        // Using std, there's no good way to detect out of memory
+        Ok(())
+    }
+
+    fn transmit(
+        &mut self,
+        frame: Frame<Microseconds64>,
+        now: Microseconds64,
+    ) -> canadensis::nb::Result<Option<Frame<Microseconds64>>, Self::Error> {
+        log::trace!("LoopbackOnlyDriver::transmit");
+        if frame.timestamp() < now {
+            log::debug!("Frame timed out");
+            return Ok(None);
+        }
+        if !frame.loopback() {
+            log::debug!("Discarding non-loopback frame");
+            return Ok(None);
+        }
+        let mut loopback_frame = frame;
+        loopback_frame.set_timestamp(now);
+        self.loopback_frames.push_back(loopback_frame);
+        Ok(None)
+    }
+
+    fn flush(&mut self, _now: Microseconds64) -> canadensis::nb::Result<(), Self::Error> {
+        // Nothing to do
+        Ok(())
+    }
+}
+impl ReceiveDriver<Microseconds64> for LoopbackOnlyDriver {
+    type Error = Infallible;
+
+    fn receive(
+        &mut self,
+        _now: Microseconds64,
+    ) -> canadensis::nb::Result<Frame<Microseconds64>, Self::Error> {
+        self.loopback_frames
+            .pop_front()
+            .map(|frame| {
+                log::trace!("Receiving loopback frame");
+                frame
+            })
+            .ok_or(canadensis::nb::Error::WouldBlock)
+    }
+
+    fn apply_filters<S>(&mut self, _local_node: Option<CanNodeId>, _subscriptions: S)
+    where
+        S: IntoIterator<Item = Subscription>,
+    {
+        // Not applicable
+    }
+
+    fn apply_accept_all(&mut self) {
+        // Not applicable
+    }
+}
+
+/// A transfer that collects all loopback transfers and panics if given any non-loopback transfer
+#[derive(Default)]
+struct LoopbackCollector {
+    transfers: Vec<Transfer<Vec<u8>, Microseconds64, CanTransport>>,
+}
+
+impl TransferHandler<Microseconds64, CanTransport> for LoopbackCollector {
+    fn handle_message<N: Node<Instant = Microseconds64, Transport = CanTransport>>(
+        &mut self,
+        _node: &mut N,
+        _transfer: &MessageTransfer<Vec<u8>, Microseconds64, CanTransport>,
+    ) -> bool {
+        panic!("handle_message() called (not loopback)");
+    }
+
+    fn handle_request<N: Node<Instant = Microseconds64, Transport = CanTransport>>(
+        &mut self,
+        _node: &mut N,
+        _token: ResponseToken<CanTransport>,
+        _transfer: &ServiceTransfer<Vec<u8>, Microseconds64, CanTransport>,
+    ) -> bool {
+        panic!("handle_request() called (not loopback)");
+    }
+
+    fn handle_response<N: Node<Instant = Microseconds64, Transport = CanTransport>>(
+        &mut self,
+        _node: &mut N,
+        _transfer: &ServiceTransfer<Vec<u8>, Microseconds64, CanTransport>,
+    ) -> bool {
+        panic!("handle_response() called (not loopback)");
+    }
+
+    fn handle_loopback<N: Node<Instant = Microseconds64, Transport = CanTransport>>(
+        &mut self,
+        _node: &mut N,
+        transfer: &Transfer<Vec<u8>, Microseconds64, CanTransport>,
+    ) -> bool {
+        self.transfers.push(transfer.clone());
+        true
+    }
+}

--- a/canadensis_bxcan/src/lib.rs
+++ b/canadensis_bxcan/src/lib.rs
@@ -34,6 +34,10 @@ use canadensis_can::driver::{optimize_filters, ReceiveDriver, TransmitDriver};
 use canadensis_can::{CanNodeId, Frame};
 use core::cmp::Ordering;
 use core::convert::{Infallible, TryFrom};
+use heapless::Deque;
+
+/// Maximum number of loopback frames that can be stored
+const LOOPBACK_CAPACITY: usize = 2;
 
 /// A CAN driver that wraps a bxCAN device and keeps track of deadlines for queued frames
 pub struct BxCanDriver<I, N>
@@ -42,11 +46,13 @@ where
 {
     can: Can<N>,
     deadlines: DeadlineTracker<I>,
+    /// Copies of transmitted loopback frames that have not yet been received
+    loopback_frames: Deque<Frame<I>, LOOPBACK_CAPACITY>,
 }
 
 impl<I, N> BxCanDriver<I, N>
 where
-    I: Clone,
+    I: Instant + Clone,
     N: Instance,
 {
     /// Creates a CAN driver
@@ -54,6 +60,7 @@ where
         BxCanDriver {
             can,
             deadlines: DeadlineTracker::new(),
+            loopback_frames: Deque::new(),
         }
     }
 
@@ -69,6 +76,75 @@ where
     /// Returns a mutable reference to the CAN driver
     pub fn can_mut(&mut self) -> &mut Can<N> {
         &mut self.can
+    }
+
+    /// Returns true if at least one loopback frame is ready to receive
+    pub fn loopback_frame_waiting(&self) -> bool {
+        !self.loopback_frames.is_empty()
+    }
+
+    /// Tries to transmit a frame, and assumes that the frame's deadline has not passed
+    fn transmit_inner(
+        &mut self,
+        frame: &Frame<I>,
+        deadline: I,
+    ) -> nb::Result<Option<Frame<I>>, <Self as TransmitDriver<I>>::Error> {
+        let frame = cyphal_frame_to_bxcan(frame);
+        match self.can.transmit(&frame) {
+            Ok(status) => {
+                // Store the deadline for this frame
+                let replaced_deadline = self.deadlines.replace(status.mailbox(), deadline);
+                if let (Some(removed_frame), Some(removed_frame_deadline)) =
+                    (status.dequeued_frame(), replaced_deadline)
+                {
+                    if let Ok(removed_frame) =
+                        bxcan_frame_to_cyphal(removed_frame, removed_frame_deadline)
+                    {
+                        Ok(Some(removed_frame))
+                    } else {
+                        // Frame that was removed is not compatible with Cyphal, so ignore it
+                        Ok(None)
+                    }
+                } else {
+                    // No frame was removed
+                    Ok(None)
+                }
+            }
+            Err(nb::Error::WouldBlock) => Err(nb::Error::WouldBlock),
+            Err(nb::Error::Other(infallible)) => match infallible {},
+        }
+    }
+}
+impl<I, N> BxCanDriver<I, N>
+where
+    I: Instant + Clone,
+    N: Instance + FilterOwner,
+{
+    /// Tries to receive a frame from the CAN bus
+    fn receive_from_bus(
+        &mut self,
+        now: I,
+    ) -> nb::Result<Frame<I>, <Self as ReceiveDriver<I>>::Error> {
+        loop {
+            match self.can.receive() {
+                Ok(frame) => {
+                    if let Ok(frame) = bxcan_frame_to_cyphal(&frame, now.clone()) {
+                        break Ok(frame);
+                    }
+                    // Otherwise the frame is remote or basic ID, not compatible with Cyphal.
+                    // Try to receive another frame.
+                }
+                Err(nb::Error::WouldBlock) => break Err(nb::Error::WouldBlock),
+                Err(nb::Error::Other(e)) => break Err(nb::Error::Other(e)),
+            }
+        }
+    }
+    /// Tries to receive a frame from the loopback queue
+    fn receive_loopback(&mut self) -> nb::Result<Frame<I>, <Self as ReceiveDriver<I>>::Error> {
+        match self.loopback_frames.pop_front() {
+            Some(frame) => Ok(frame),
+            None => Err(nb::Error::WouldBlock),
+        }
     }
 }
 
@@ -96,30 +172,15 @@ where
         match deadline.overflow_safe_compare(&now) {
             Ordering::Greater | Ordering::Equal => {
                 // Deadline is now or in the future. Continue to transmit.
-                let frame = cyphal_frame_to_bxcan(&frame);
-                match self.can.transmit(&frame) {
-                    Ok(status) => {
-                        // Store the deadline for this frame
-                        let replaced_deadline = self.deadlines.replace(status.mailbox(), deadline);
-                        if let (Some(removed_frame), Some(removed_frame_deadline)) =
-                            (status.dequeued_frame(), replaced_deadline)
-                        {
-                            if let Ok(removed_frame) =
-                                bxcan_frame_to_cyphal(removed_frame, removed_frame_deadline)
-                            {
-                                Ok(Some(removed_frame))
-                            } else {
-                                // Frame that was removed is not compatible with Cyphal, so ignore it
-                                Ok(None)
-                            }
-                        } else {
-                            // No frame was removed
-                            Ok(None)
-                        }
-                    }
-                    Err(nb::Error::WouldBlock) => Err(nb::Error::WouldBlock),
-                    Err(nb::Error::Other(infallible)) => match infallible {},
+                let transmit_status = self.transmit_inner(&frame, deadline);
+                if transmit_status.is_ok() && frame.loopback() {
+                    // Loopback frame successfully sent; store a copy with its timestamp set to now
+                    let mut loopback_frame = frame;
+                    loopback_frame.set_timestamp(now);
+                    // If the loopback queue is full, drop this frame
+                    let _ = self.loopback_frames.push_back(loopback_frame);
                 }
+                transmit_status
             }
             Ordering::Less => {
                 // Deadline passed, ignore frame
@@ -142,19 +203,17 @@ where
     /// This matches the error type defined in bxcan
     type Error = OverrunError;
 
+    /// Tries to receive a frame from the frame receive queue or the loopback frame queue
+    ///
+    /// If both loopback and non-loopback frames are waiting, this function returns a non-loopback
+    /// frame.
+    ///
     fn receive(&mut self, now: I) -> nb::Result<Frame<I>, Self::Error> {
-        loop {
-            match self.can.receive() {
-                Ok(frame) => {
-                    if let Ok(frame) = bxcan_frame_to_cyphal(&frame, now) {
-                        break Ok(frame);
-                    }
-                    // Otherwise the frame is remote or basic ID, not compatible with Cyphal.
-                    // Try to receive another frame.
-                }
-                Err(nb::Error::WouldBlock) => break Err(nb::Error::WouldBlock),
-                Err(nb::Error::Other(e)) => break Err(nb::Error::Other(e)),
-            }
+        match self.receive_from_bus(now) {
+            Ok(frame) => Ok(frame),
+            Err(nb::Error::Other(e)) => Err(nb::Error::Other(e)),
+            // No frames waiting from the bus. Try the loopback queue.
+            Err(nb::Error::WouldBlock) => self.receive_loopback(),
         }
     }
 

--- a/canadensis_bxcan/src/pnp.rs
+++ b/canadensis_bxcan/src/pnp.rs
@@ -17,10 +17,10 @@ pub struct BxCanPnpClient<C: Clock, M, I: Instance + FilterOwner> {
     pub client: PnpClient<
         C,
         M,
-        CanTransmitter<C, SingleQueueDriver<SingleFrameQueue<C::Instant>, BxCanDriver<C, I>>>,
-        CanReceiver<C::Instant, SingleQueueDriver<SingleFrameQueue<C::Instant>, BxCanDriver<C, I>>>,
+        CanTransmitter<C, SingleQueueDriver<C, SingleFrameQueue<C::Instant>, BxCanDriver<C, I>>>,
+        CanReceiver<C, SingleQueueDriver<C, SingleFrameQueue<C::Instant>, BxCanDriver<C, I>>>,
     >,
-    driver: SingleQueueDriver<SingleFrameQueue<C::Instant>, BxCanDriver<C, I>>,
+    driver: SingleQueueDriver<C, SingleFrameQueue<C::Instant>, BxCanDriver<C, I>>,
 }
 
 impl<C, M, I> BxCanPnpClient<C, M, I>
@@ -51,8 +51,8 @@ where
     }
 
     /// Handles and parses incoming CAN frames, and returns a node ID if one was received
-    pub fn handle_incoming_frames(&mut self, now: C::Instant) -> Option<CanNodeId> {
-        match self.client.receive(now, &mut self.driver) {
+    pub fn handle_incoming_frames(&mut self, clock: &mut C) -> Option<CanNodeId> {
+        match self.client.receive(clock, &mut self.driver) {
             Ok(Some(id)) => Some(id),
             Ok(None) | Err(_) => None,
         }

--- a/canadensis_bxcan/src/pnp.rs
+++ b/canadensis_bxcan/src/pnp.rs
@@ -17,16 +17,10 @@ pub struct BxCanPnpClient<C: Clock, M, I: Instance + FilterOwner> {
     pub client: PnpClient<
         C,
         M,
-        CanTransmitter<
-            C::Instant,
-            SingleQueueDriver<SingleFrameQueue<C::Instant>, BxCanDriver<C::Instant, I>>,
-        >,
-        CanReceiver<
-            C::Instant,
-            SingleQueueDriver<SingleFrameQueue<C::Instant>, BxCanDriver<C::Instant, I>>,
-        >,
+        CanTransmitter<C, SingleQueueDriver<SingleFrameQueue<C::Instant>, BxCanDriver<C, I>>>,
+        CanReceiver<C::Instant, SingleQueueDriver<SingleFrameQueue<C::Instant>, BxCanDriver<C, I>>>,
     >,
-    driver: SingleQueueDriver<SingleFrameQueue<C::Instant>, BxCanDriver<C::Instant, I>>,
+    driver: SingleQueueDriver<SingleFrameQueue<C::Instant>, BxCanDriver<C, I>>,
 }
 
 impl<C, M, I> BxCanPnpClient<C, M, I>

--- a/canadensis_can/src/data.rs
+++ b/canadensis_can/src/data.rs
@@ -111,6 +111,12 @@ impl<I> Frame<I> {
         }
     }
 
+    /// Sets the timestamp
+    #[inline]
+    pub fn set_timestamp(&mut self, timestamp: I) {
+        self.timestamp = timestamp;
+    }
+
     /// Sets the loopback flag
     #[inline]
     pub fn set_loopback(&mut self, loopback: bool) {

--- a/canadensis_can/src/driver.rs
+++ b/canadensis_can/src/driver.rs
@@ -48,11 +48,14 @@ where
 ///
 /// The result type is `nb::Result`, which allows the driver to indicate that no frame is available
 /// to receive.
-pub trait ReceiveDriver<I> {
+pub trait ReceiveDriver<C>
+where
+    C: Clock,
+{
     /// The error type
     type Error: Debug;
     /// Attempts to receive a frame without blocking
-    fn receive(&mut self, now: I) -> nb::Result<Frame<I>, Self::Error>;
+    fn receive(&mut self, clock: &mut C) -> nb::Result<Frame<C::Instant>, Self::Error>;
 
     /// Sets up frame reception filters to accept only frames matching the provided subscriptions
     ///

--- a/canadensis_can/src/queue/queue_only_driver.rs
+++ b/canadensis_can/src/queue/queue_only_driver.rs
@@ -114,12 +114,12 @@ where
     }
 }
 
-impl<I: Default + Clone, const TC: usize, const RC: usize> ReceiveDriver<I>
-    for QueueOnlyDriver<I, TC, RC>
+impl<C: Clock, const TC: usize, const RC: usize> ReceiveDriver<C>
+    for QueueOnlyDriver<C::Instant, TC, RC>
 {
     type Error = Infallible;
 
-    fn receive(&mut self, _now: I) -> nb::Result<Frame<I>, Self::Error> {
+    fn receive(&mut self, _clock: &mut C) -> nb::Result<Frame<C::Instant>, Self::Error> {
         self.rx_queue.pop_front().ok_or(nb::Error::WouldBlock)
     }
 

--- a/canadensis_can/src/rx.rs
+++ b/canadensis_can/src/rx.rs
@@ -288,17 +288,12 @@ where
         self.accept_sane_frame(frame, frame_header, tail)
     }
 
+    /// Returns true if this node is not anonymous and matches the destination node ID of the
+    /// provided service header
     fn can_accept_service(&self, service_header: &ServiceHeader<C::Instant, CanTransport>) -> bool {
-        if let Some(this_id) = self.id {
-            if service_header.destination != this_id {
-                // This frame is a service request or response going to some other node
-                false
-            } else {
-                true
-            }
-        } else {
-            // This node is anonymous, so it must ignore all service frames
-            false
+        match self.id {
+            Some(local_id) if local_id == service_header.destination => true,
+            Some(_) | None => false,
         }
     }
 

--- a/canadensis_can/src/rx/subscription.rs
+++ b/canadensis_can/src/rx/subscription.rs
@@ -98,6 +98,7 @@ impl<I: Instant> Subscription<I> {
             payload.try_extend_from_slice(data_without_tail)?;
             let transfer = Transfer {
                 header: frame_header,
+                loopback: frame.loopback(),
                 payload,
             };
             Ok(Some(transfer))
@@ -138,6 +139,7 @@ impl<I: Instant> Subscription<I> {
                     frame_header.timestamp(),
                     tail.transfer_id,
                     self.payload_size_max,
+                    frame.loopback(),
                 )?)?);
                 log::debug!(
                     "Created new session for transfer ID {:?} on port {:?}",
@@ -186,6 +188,7 @@ impl<I: Instant> Subscription<I> {
 
         Ok(Some(Transfer {
             header: frame_header,
+            loopback: frame.loopback(),
             payload: transfer_data,
         }))
     }

--- a/canadensis_can/src/tx.rs
+++ b/canadensis_can/src/tx.rs
@@ -67,6 +67,7 @@ where
         // Convert the transfer payload into borrowed form
         let transfer = Transfer {
             header: transfer.header,
+            loopback: transfer.loopback,
             payload: transfer.payload.as_ref(),
         };
 
@@ -153,6 +154,7 @@ where
                 // Filled up a frame
                 self.push_frame(
                     transfer.header.timestamp(),
+                    transfer.loopback,
                     can_id,
                     &frame_data,
                     driver,
@@ -173,6 +175,7 @@ where
                     // Filled up a frame
                     self.push_frame(
                         transfer.header.timestamp(),
+                        transfer.loopback,
                         can_id,
                         &frame_data,
                         driver,
@@ -185,6 +188,7 @@ where
         let last_frame_data = breakdown.finish();
         self.push_frame(
             transfer.header.timestamp(),
+            transfer.loopback,
             can_id,
             &last_frame_data,
             driver,
@@ -200,6 +204,7 @@ where
     fn push_frame(
         &mut self,
         timestamp: I,
+        loopback: bool,
         id: CanId,
         data: &[u8],
         driver: &mut D,
@@ -208,7 +213,8 @@ where
     where
         I: Clone,
     {
-        let frame = Frame::new(timestamp, id, data);
+        let mut frame = Frame::new(timestamp, id, data);
+        frame.set_loopback(loopback);
         // If a lower-priority frame was removed, drop it
         driver.transmit(frame, now).map(drop)
     }

--- a/canadensis_can/tests/rx.rs
+++ b/canadensis_can/tests/rx.rs
@@ -54,6 +54,7 @@ fn test_heartbeat() {
             subject: heartbeat_subject,
             source: Some(42u8.try_into().unwrap()),
         }),
+        loopback: false,
         payload: vec![0x00, 0x00, 0x00, 0x00, 0x04, 0x78, 0x68],
     };
     assert_eq!(expected, transfer);
@@ -86,6 +87,7 @@ fn test_string() {
             subject: string_subject,
             source: None,
         }),
+        loopback: false,
         payload: b"\x00\x18Hello world!\x00".to_vec(),
     };
     assert_eq!(expected, transfer);
@@ -118,6 +120,7 @@ fn test_node_info_request() {
             source: 123u8.try_into().unwrap(),
             destination: 42u8.try_into().unwrap(),
         }),
+        loopback: false,
         payload: vec![],
     };
     assert_eq!(expected, transfer);
@@ -188,6 +191,7 @@ fn test_node_info_response() {
                     source: 42u8.try_into().unwrap(),
                     destination: 123u8.try_into().unwrap(),
                 }),
+                loopback: false,
                 payload: payload.to_vec(),
             };
             assert_eq!(expected, transfer);
@@ -248,6 +252,7 @@ fn test_array() {
             subject,
             source: Some(59u8.try_into().unwrap()),
         }),
+        loopback: false,
         payload: [
             0x00, 0xb8, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
             0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19,
@@ -335,6 +340,7 @@ fn test_multi_frame_anonymous() {
             subject: subject_id,
             source: Some(64u8.try_into().unwrap()),
         }),
+        loopback: false,
         payload: vec![0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8],
     };
 
@@ -385,6 +391,7 @@ fn test_anonymous_receive_multi_frame() {
             subject: 8166.try_into().unwrap(),
             source: Some(126u8.try_into().unwrap()),
         }),
+        loopback: false,
         payload: vec![190, 159, 33, 213, 34, 64, 1, 103, 0],
     };
 

--- a/canadensis_can/tests/tx.rs
+++ b/canadensis_can/tests/tx.rs
@@ -33,6 +33,7 @@ fn test_heartbeat() {
                 subject: SubjectId::try_from(7509).unwrap(),
                 source: Some(CanNodeId::try_from(42u8).unwrap()),
             }),
+            loopback: false,
             payload: &[0x00, 0x00, 0x00, 0x00, 0x04, 0x78, 0x68],
         },
         &mut ZeroClock,
@@ -60,6 +61,7 @@ fn test_heartbeat() {
                 subject: SubjectId::try_from(7509).unwrap(),
                 source: Some(CanNodeId::try_from(42u8).unwrap()),
             }),
+            loopback: false,
             payload: &[0x01, 0x00, 0x00, 0x00, 0x04, 0x78, 0x68],
         },
         &mut ZeroClock,
@@ -92,6 +94,7 @@ fn test_string() {
                 subject: SubjectId::try_from(4919).unwrap(),
                 source: None,
             }),
+            loopback: false,
             payload: &[
                 0x00, 0x18, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x21,
             ],
@@ -129,6 +132,7 @@ fn test_node_info_request() {
                 source: CanNodeId::try_from(123u8).unwrap(),
                 destination: CanNodeId::try_from(42u8).unwrap(),
             }),
+            loopback: false,
             payload: &[],
         },
         &mut ZeroClock,
@@ -161,6 +165,7 @@ fn test_node_info_response() {
                 source: CanNodeId::try_from(42u8).unwrap(),
                 destination: CanNodeId::try_from(123u8).unwrap(),
             }),
+            loopback: false,
             payload: &b"\x01\x00\x00\x00\x01\x00\x00\
                     \x00\x00\x00\x00\x00\x00\x00\
                     \x00\x00\x00\x00\x00\x00\x00\
@@ -213,6 +218,7 @@ fn test_array() {
                 subject: SubjectId::try_from(4919).unwrap(),
                 source: Some(CanNodeId::try_from(59u8).unwrap()),
             }),
+            loopback: false,
             payload: &[
                 0x00, 0xb8, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
                 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19,

--- a/canadensis_codegen_rust/src/main.rs
+++ b/canadensis_codegen_rust/src/main.rs
@@ -173,7 +173,7 @@ fn get_args() -> Args {
 
 /// Validates an external package name pair
 fn validate_external_package(package: &str) -> Result<ExternalPackage, String> {
-    ExternalPackage::parse(&package).ok_or_else(|| {
+    ExternalPackage::parse(package).ok_or_else(|| {
         "Invalid external package, expected [cyphal-package],[rust-module-path]".into()
     })
 }

--- a/canadensis_core/src/transfer.rs
+++ b/canadensis_core/src/transfer.rs
@@ -276,6 +276,15 @@ impl<I, T: Transport + ?Sized> Header<I, T> {
 pub struct Transfer<A, I, T: Transport + ?Sized> {
     /// The transfer header
     pub header: Header<I, T>,
+    /// The loopback flag
+    ///
+    /// The exact meaning of this flag depends on the transport. Generally, when a transport
+    /// handles an outgoing loopback transfer, it creates a duplicate transfer with the loopback
+    /// flag set to true and sends that transfer back through the local receiving process.
+    ///
+    /// If the transport does not support loopback, this flag has no effect.
+    ///
+    pub loopback: bool,
     /// The actual transfer payload
     ///
     /// The type A usually implements `AsRef<[u8]>`. It is often a `Vec<u8>` or a `&[u8]`.
@@ -290,6 +299,7 @@ where
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Transfer")
             .field("header", &self.header)
+            .field("loopback", &self.loopback)
             .field("payload", &self.payload)
             .finish()
     }
@@ -304,7 +314,9 @@ where
     T::NodeId: PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
-        self.header == other.header && self.payload == other.payload
+        self.header == other.header
+            && self.loopback == other.loopback
+            && self.payload == other.payload
     }
 }
 impl<A, I, T: Transport + ?Sized> Clone for Transfer<A, I, T>
@@ -318,6 +330,7 @@ where
     fn clone(&self) -> Self {
         Transfer {
             header: self.header.clone(),
+            loopback: self.loopback,
             payload: self.payload.clone(),
         }
     }
@@ -328,6 +341,15 @@ where
 pub struct MessageTransfer<A, I, T: Transport + ?Sized> {
     /// The transfer header
     pub header: MessageHeader<I, T>,
+    /// The loopback flag
+    ///
+    /// The exact meaning of this flag depends on the transport. Generally, when a transport
+    /// handles an outgoing loopback transfer, it creates a duplicate transfer with the loopback
+    /// flag set to true and sends that transfer back through the local receiving process.
+    ///
+    /// If the transport does not support loopback, this flag has no effect.
+    ///
+    pub loopback: bool,
     /// The actual transfer payload
     ///
     /// The type A usually implements `AsRef<[u8]>`. It is often a `Vec<u8>` or a `&[u8]`.
@@ -342,6 +364,7 @@ where
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Transfer")
             .field("header", &self.header)
+            .field("loopback", &self.loopback)
             .field("payload", &self.payload)
             .finish()
     }
@@ -356,7 +379,9 @@ where
     T::NodeId: PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
-        self.header == other.header && self.payload == other.payload
+        self.header == other.header
+            && self.loopback == other.loopback
+            && self.payload == other.payload
     }
 }
 
@@ -365,6 +390,15 @@ where
 pub struct ServiceTransfer<A, I, T: Transport + ?Sized> {
     /// The transfer header
     pub header: ServiceHeader<I, T>,
+    /// The loopback flag
+    ///
+    /// The exact meaning of this flag depends on the transport. Generally, when a transport
+    /// handles an outgoing loopback transfer, it creates a duplicate transfer with the loopback
+    /// flag set to true and sends that transfer back through the local receiving process.
+    ///
+    /// If the transport does not support loopback, this flag has no effect.
+    ///
+    pub loopback: bool,
     /// The actual transfer payload
     ///
     /// The type A usually implements `AsRef<[u8]>`. It is often a `Vec<u8>` or a `&[u8]`.
@@ -379,6 +413,7 @@ where
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Transfer")
             .field("header", &self.header)
+            .field("loopback", &self.loopback)
             .field("payload", &self.payload)
             .finish()
     }
@@ -393,6 +428,8 @@ where
     T::NodeId: PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
-        self.header == other.header && self.payload == other.payload
+        self.header == other.header
+            && self.loopback == other.loopback
+            && self.payload == other.payload
     }
 }

--- a/canadensis_core/src/transport.rs
+++ b/canadensis_core/src/transport.rs
@@ -22,9 +22,9 @@ pub trait Transport {
 }
 
 /// A transmitter that can send outgoing transfers
-pub trait Transmitter<I>
+pub trait Transmitter<C>
 where
-    I: Instant,
+    C: Clock,
 {
     /// The transport that this transmitter works with
     type Transport: Transport;
@@ -39,15 +39,14 @@ where
     ///
     /// The transport implementation may block until the entire transfer is sent, or put frames in
     /// a queue to be sent separately.
-    fn push<A, C>(
+    fn push<A>(
         &mut self,
-        transfer: Transfer<A, I, Self::Transport>,
+        transfer: Transfer<A, C::Instant, Self::Transport>,
         clock: &mut C,
         driver: &mut Self::Driver,
     ) -> nb::Result<(), Self::Error>
     where
-        A: AsRef<[u8]>,
-        C: Clock<Instant = I>;
+        A: AsRef<[u8]>;
 
     /// Attempts to send all queued outgoing frames
     ///
@@ -61,9 +60,7 @@ where
     /// * `Ok(())`: All frames were sent
     /// * `Err(nb::Error::WouldBlock)`: At least one frame could not be sent yet
     /// * `Err(nb::Error::Other(e))`: Some other error occurred
-    fn flush<C>(&mut self, clock: &mut C, driver: &mut Self::Driver) -> nb::Result<(), Self::Error>
-    where
-        C: Clock<Instant = I>;
+    fn flush(&mut self, clock: &mut C, driver: &mut Self::Driver) -> nb::Result<(), Self::Error>;
 
     /// Returns the maximum transmission unit of this transport, in bytes
     ///

--- a/canadensis_core/src/transport.rs
+++ b/canadensis_core/src/transport.rs
@@ -72,9 +72,9 @@ where
 }
 
 /// A receiver that can assemble incoming frames into transfers
-pub trait Receiver<I>
+pub trait Receiver<C>
 where
-    I: Instant,
+    C: Clock,
 {
     /// The transport that this transmitter works with
     type Transport: Transport;
@@ -103,9 +103,9 @@ where
     /// incoming frames and delete sessions that have timed out.
     fn receive(
         &mut self,
-        now: I,
+        clock: &mut C,
         driver: &mut Self::Driver,
-    ) -> Result<Option<Transfer<Vec<u8>, I, Self::Transport>>, Self::Error>;
+    ) -> Result<Option<Transfer<Vec<u8>, C::Instant, Self::Transport>>, Self::Error>;
 
     /// Subscribes to messages on a subject
     ///
@@ -125,7 +125,7 @@ where
         &mut self,
         subject: SubjectId,
         payload_size_max: usize,
-        timeout: I::Duration,
+        timeout: <<C as Clock>::Instant as Instant>::Duration,
         driver: &mut Self::Driver,
     ) -> Result<(), Self::Error>;
 
@@ -154,7 +154,7 @@ where
         &mut self,
         service: ServiceId,
         payload_size_max: usize,
-        timeout: I::Duration,
+        timeout: <<C as Clock>::Instant as Instant>::Duration,
         driver: &mut Self::Driver,
     ) -> Result<(), ServiceSubscribeError<Self::Error>>;
 
@@ -183,7 +183,7 @@ where
         &mut self,
         service: ServiceId,
         payload_size_max: usize,
-        timeout: I::Duration,
+        timeout: <<C as Clock>::Instant as Instant>::Duration,
         driver: &mut Self::Driver,
     ) -> Result<(), ServiceSubscribeError<Self::Error>>;
 

--- a/canadensis_dsdl_frontend/src/compile.rs
+++ b/canadensis_dsdl_frontend/src/compile.rs
@@ -299,7 +299,7 @@ impl PersistentContext {
                 }
                 Statement::Field { ty, name, span } => {
                     let ty = convert_type(&mut ctx(self, &mut state), ty)?;
-                    let ty = ty.resolve(&mut ctx(self, &mut state), span.clone())?;
+                    let ty = ty.resolve(&mut ctx(self, &mut state), span)?;
                     let ty_alignment = ty.alignment();
                     let ty_length = ty.size();
 

--- a/canadensis_dsdl_frontend/src/operators/exponent.rs
+++ b/canadensis_dsdl_frontend/src/operators/exponent.rs
@@ -38,14 +38,14 @@ fn approx_exponent(
 ) -> Result<Value, Error> {
     let base = base.to_f64().ok_or_else(|| {
         span_error!(
-            span.clone(),
+            span,
             "Can't convert base {} to a floating-point approximation",
             base
         )
     })?;
     let exponent = exponent.to_f64().ok_or_else(|| {
         span_error!(
-            span.clone(),
+            span,
             "Can't convert exponent {} to a floating-point approximation",
             exponent
         )

--- a/canadensis_dsdl_frontend/src/operators/mod.rs
+++ b/canadensis_dsdl_frontend/src/operators/mod.rs
@@ -48,7 +48,7 @@ where
             let new_elements: Result<Set, TypeError> = set
                 .into_iter()
                 .map(|element| match element {
-                    Value::Rational(rhs) => rational_op(lhs.clone(), rhs, span.clone()),
+                    Value::Rational(rhs) => rational_op(lhs.clone(), rhs, span),
                     _ => panic!(
                         "Element {:?} does not match set type {}",
                         element,
@@ -64,7 +64,7 @@ where
             let new_elements: Result<Set, TypeError> = set
                 .into_iter()
                 .map(|element| match element {
-                    Value::Rational(lhs) => rational_op(lhs, rhs.clone(), span.clone()),
+                    Value::Rational(lhs) => rational_op(lhs, rhs.clone(), span),
                     _ => panic!(
                         "Element {:?} does not match set type {}",
                         element,

--- a/canadensis_dsdl_frontend/src/types/constant.rs
+++ b/canadensis_dsdl_frontend/src/types/constant.rs
@@ -37,7 +37,7 @@ impl Constant {
         value: Expression,
     ) -> Result<Self, Error> {
         let ty: PrimitiveType = ty.into();
-        let value_span = value.span.clone();
+        let value_span = value.span;
         let end_offset = value_span.end();
         if is_reserved_keyword(name.name) {
             return Err(span_error!(

--- a/canadensis_dsdl_frontend/src/types/directive.rs
+++ b/canadensis_dsdl_frontend/src/types/directive.rs
@@ -23,7 +23,7 @@ pub(crate) fn evaluate_directive(
         }
         "extent" => match expression {
             Some(expression) => {
-                let expression_span = expression.span.clone();
+                let expression_span = expression.span;
                 match evaluate_expression(cx, expression)? {
                     Value::Rational(value) => {
                         if value.is_integer() && !value.is_negative() {
@@ -86,7 +86,7 @@ pub(crate) fn evaluate_directive(
         }
         "assert" => match expression {
             Some(expr) => {
-                let expr_span = expr.span.clone();
+                let expr_span = expr.span;
                 match evaluate_expression(cx, expr)? {
                     Value::Boolean(true) => Ok(()),
                     Value::Boolean(false) => Err(span_error!(expr_span, "Assertion failed")),

--- a/canadensis_dsdl_frontend/src/types/expression.rs
+++ b/canadensis_dsdl_frontend/src/types/expression.rs
@@ -278,7 +278,7 @@ fn evaluate_array_length(
     cx: &mut CompileContext<'_>,
     length: Expression<'_>,
 ) -> Result<u64, Error> {
-    let length_span = length.span.clone();
+    let length_span = length.span;
     match evaluate_expression(cx, length)? {
         Value::Rational(rational) => {
             if rational.is_integer() {
@@ -359,7 +359,7 @@ pub(crate) fn convert_type(
                     })
                 }
                 canadensis_dsdl_parser::ArrayLength::Exclusive(length) => {
-                    let length_span = length.span.clone();
+                    let length_span = length.span;
                     let length = evaluate_array_length(cx, length)?;
                     if length > 0 {
                         // Convert to inclusive length by subtracting 1

--- a/canadensis_dsdl_parser/src/ast.rs
+++ b/canadensis_dsdl_parser/src/ast.rs
@@ -196,7 +196,7 @@ fn parse_expression(pair: Pair<'_, Rule>) -> Result<Expression<'_>, Error> {
 
                 expression = Expression {
                     expression: ExpressionType::Attribute(Box::new(expression), rhs.as_str()),
-                    span: pair_span.clone(),
+                    span: pair_span,
                 };
             }
 
@@ -250,7 +250,7 @@ where
         let new_expr_type = op_handler(operator_rule, Box::new(expression), Box::new(rhs));
         expression = Expression {
             expression: new_expr_type,
-            span: span.clone(),
+            span,
         };
     }
 
@@ -463,7 +463,7 @@ fn parse_real_point_notation(literal: Pair<'_, Rule>) -> Result<BigRational, Err
     let whole_number_digits: BigInt = whole_number_digits
         .as_str()
         .parse()
-        .map_err(|e| make_error(format!("Invalid real literal: {}", e), span.clone()))?;
+        .map_err(|e| make_error(format!("Invalid real literal: {}", e), span))?;
 
     if let Some(fractional_digits) = fractional_digits {
         debug_assert_eq!(fractional_digits.as_rule(), Rule::literal_real_digits);

--- a/canadensis_dsdl_parser/src/ast/unescape.rs
+++ b/canadensis_dsdl_parser/src/ast/unescape.rs
@@ -64,7 +64,7 @@ pub fn unescape_string(s: &str, span: Span<'_>) -> Result<String, Error> {
                     _ => {
                         return Err(make_error(
                             format!("Unexpected character '{}' after \\ in string literal", c),
-                            span.clone(),
+                            span,
                         ))
                     }
                 }
@@ -90,11 +90,11 @@ pub fn unescape_string(s: &str, span: Span<'_>) -> Result<String, Error> {
                             "Invalid 4-digit unicode escape sequence \"\\u{}\": {}",
                             escape_chars, e
                         ),
-                        span.clone(),
+                        span,
                     )
                 })?;
                 let constructed = char::from_u32(value.into()).ok_or_else(||
-                    make_error(format!("Unicode escape sequence \\u{:04x} does not represent a valid scalar value", value), span.clone())
+                    make_error(format!("Unicode escape sequence \\u{:04x} does not represent a valid scalar value", value), span)
                 )?;
                 unescaped.push(constructed);
                 State::Idle
@@ -136,11 +136,11 @@ pub fn unescape_string(s: &str, span: Span<'_>) -> Result<String, Error> {
                             "Invalid 8-digit unicode escape sequence \"\\U{}\": {}",
                             escape_chars, e
                         ),
-                        span.clone(),
+                        span,
                     )
                 })?;
                 let constructed = char::from_u32(value).ok_or_else(||
-                    make_error(format!("Unicode escape sequence \\U{:08x} does not represent a valid scalar value", value), span.clone())
+                    make_error(format!("Unicode escape sequence \\U{:08x} does not represent a valid scalar value", value), span)
                 )?;
                 unescaped.push(constructed);
                 State::Idle

--- a/canadensis_linux/src/lib.rs
+++ b/canadensis_linux/src/lib.rs
@@ -73,15 +73,18 @@ impl TransmitDriver<SystemClock> for LinuxCan {
     }
 }
 
-impl ReceiveDriver<Microseconds64> for LinuxCan {
+impl ReceiveDriver<SystemClock> for LinuxCan {
     type Error = io::Error;
 
-    fn receive(&mut self, now: Microseconds64) -> nb::Result<Frame<Microseconds64>, Self::Error> {
+    fn receive(
+        &mut self,
+        clock: &mut SystemClock,
+    ) -> nb::Result<Frame<Microseconds64>, Self::Error> {
         loop {
             let socketcan_frame = self.socket.read_frame()?;
             if socketcan_frame.data().len() <= canadensis_can::FRAME_CAPACITY {
                 let cyphal_frame = canadensis_can::Frame::new(
-                    now,
+                    clock.now(),
                     socketcan_frame.id().try_into().expect("Invalid CAN ID"),
                     socketcan_frame.data(),
                 );

--- a/canadensis_pnp_client/src/lib.rs
+++ b/canadensis_pnp_client/src/lib.rs
@@ -26,7 +26,7 @@ use core::marker::PhantomData;
 use crc_any::CRCu64;
 
 /// A plug-and-play allocation client that can be used to find a node ID
-pub struct PnpClient<C: Clock, M, T: Transmitter<C::Instant>, R: Receiver<C::Instant>> {
+pub struct PnpClient<C: Clock, M, T: Transmitter<C>, R: Receiver<C::Instant>> {
     /// The unique ID of this node
     unique_id: [u8; 16],
     /// Publisher used to send messages
@@ -42,7 +42,7 @@ impl<C, M, T, R, P> PnpClient<C, M, T, R>
 where
     C: Clock,
     M: AllocationMessage<P>,
-    T: Transmitter<C::Instant, Transport = P>,
+    T: Transmitter<C, Transport = P>,
     R: Receiver<C::Instant, Transport = P>,
     P: Transport,
 {

--- a/canadensis_serial/src/rx.rs
+++ b/canadensis_serial/src/rx.rs
@@ -377,7 +377,11 @@ where
                         },
                     );
                 }
-                Some(Transfer { header, payload })
+                Some(Transfer {
+                    header,
+                    loopback: false,
+                    payload,
+                })
             } else {
                 // The subscription was removed while receiving the transfer
                 None

--- a/canadensis_serial/tests/round_trip.rs
+++ b/canadensis_serial/tests/round_trip.rs
@@ -36,6 +36,7 @@ fn round_trip_no_payload() {
             subject,
             source: Some(37u16.try_into().unwrap()),
         }),
+        loopback: false,
         payload: vec![],
     };
     tx.push(transfer.clone(), &mut ZeroClock, &mut driver)

--- a/canadensis_serial/tests/round_trip.rs
+++ b/canadensis_serial/tests/round_trip.rs
@@ -45,17 +45,17 @@ fn round_trip_no_payload() {
     let wire_bytes: Vec<u8> = driver.iter().copied().collect();
     println!("{:02x?}", wire_bytes);
 
-    let mut rx = SerialReceiver::<
-        Microseconds32,
+    let mut rx: SerialReceiver<
+        ZeroClock,
         MockDriver,
         DynamicSubscriptionManager<Subscription<Microseconds32>>,
-    >::new(SerialNodeId::try_from(360).unwrap());
+    > = SerialReceiver::new(SerialNodeId::try_from(360).unwrap());
     rx.subscribe_message(subject, 0, MicrosecondDuration32::new(0), &mut driver)
         .unwrap();
 
     // Only need to call receive once. It will read all the available frames.
     let received = rx
-        .receive(Microseconds32::new(0), &mut driver)
+        .receive(&mut ZeroClock, &mut driver)
         .unwrap()
         .expect("No transfer");
 

--- a/canadensis_serial/tests/tx.rs
+++ b/canadensis_serial/tests/tx.rs
@@ -22,6 +22,7 @@ fn transmit_capacity_1() {
             subject: 9u16.try_into().unwrap(),
             source: Some(37u16.try_into().unwrap()),
         }),
+        loopback: false,
         payload: [],
     };
     assert!(tx.push(transfer, &mut ZeroClock, &mut driver).is_err());
@@ -42,6 +43,7 @@ fn transmit_minimum_capacity() {
             subject: 9u16.try_into().unwrap(),
             source: Some(37u16.try_into().unwrap()),
         }),
+        loopback: false,
         payload: [],
     };
     tx.push(transfer, &mut ZeroClock, &mut driver).unwrap();

--- a/canadensis_udp/examples/receive.rs
+++ b/canadensis_udp/examples/receive.rs
@@ -15,7 +15,7 @@ use simplelog::{ColorChoice, TermLogger};
 use zerocopy::AsBytes;
 
 use canadensis_core::session::SessionDynamicMap;
-use canadensis_core::time::{Clock, MicrosecondDuration64, Microseconds64};
+use canadensis_core::time::{MicrosecondDuration64, Microseconds64};
 use canadensis_core::transport::Receiver;
 use canadensis_linux::SystemClock;
 use canadensis_udp::driver::StdUdpSocket;
@@ -38,7 +38,7 @@ fn main() {
     // Note: This MTU includes space for the header
     const MTU: usize = 1472;
     let mut receiver = UdpReceiver::<
-        Microseconds64,
+        SystemClock,
         SessionDynamicMap<Microseconds64, UdpNodeId, UdpTransferId, UdpSessionData>,
         StdUdpSocket,
         MTU,
@@ -54,7 +54,7 @@ fn main() {
 
     // Instead of a real asynchronous IO system, just poll periodically
     loop {
-        match receiver.receive(clock.now(), &mut socket) {
+        match receiver.receive(&mut clock, &mut socket) {
             Ok(Some(transfer)) => {
                 println!("{:#?}", transfer.header);
                 for byte in transfer.payload.as_bytes() {

--- a/canadensis_udp/examples/transmit.rs
+++ b/canadensis_udp/examples/transmit.rs
@@ -57,6 +57,7 @@ fn main() {
                 subject: SubjectId::try_from(73u16).unwrap(),
                 source: Some(local_node_id),
             }),
+            loopback: false,
             payload: &payload,
         };
 

--- a/canadensis_udp/src/rx.rs
+++ b/canadensis_udp/src/rx.rs
@@ -367,6 +367,7 @@ where
                 };
                 Ok(Some(Transfer {
                     header,
+                    loopback: false,
                     payload: reassembled,
                 }))
             }

--- a/canadensis_udp/src/tx.rs
+++ b/canadensis_udp/src/tx.rs
@@ -84,24 +84,23 @@ where
     }
 }
 
-impl<I, S, const MTU: usize> Transmitter<I> for UdpTransmitter<S, MTU>
+impl<C, S, const MTU: usize> Transmitter<C> for UdpTransmitter<S, MTU>
 where
-    I: Instant,
+    C: Clock,
     S: crate::driver::UdpSocket,
 {
     type Transport = UdpTransport;
     type Driver = S;
     type Error = Error<S::Error>;
 
-    fn push<A, C>(
+    fn push<A>(
         &mut self,
-        transfer: Transfer<A, I, Self::Transport>,
+        transfer: Transfer<A, C::Instant, Self::Transport>,
         clock: &mut C,
         socket: &mut S,
     ) -> nb::Result<(), Self::Error>
     where
         A: AsRef<[u8]>,
-        C: Clock<Instant = I>,
     {
         let deadline = transfer.header.timestamp();
         let (header_base, dest_address) = match transfer.header {
@@ -159,14 +158,11 @@ where
         .map_err(nb::Error::Other)
     }
 
-    fn flush<C>(
+    fn flush(
         &mut self,
         _clock: &mut C,
         _socket: &mut S,
-    ) -> canadensis_core::nb::Result<(), Self::Error>
-    where
-        C: Clock<Instant = I>,
-    {
+    ) -> canadensis_core::nb::Result<(), Self::Error> {
         // Because the push() function blocks until everything has been transmitted, nothing is
         // needed here.
         Ok(())

--- a/canadensis_udp/tests/loopback_transmit_receive.rs
+++ b/canadensis_udp/tests/loopback_transmit_receive.rs
@@ -51,6 +51,7 @@ fn transmit_receive_message_two_frames() {
             subject: SubjectId::try_from(73u16).unwrap(),
             source: Some(transmit_node_id),
         }),
+        loopback: false,
         payload,
     };
     check_loopback::<_, _, MTU>(
@@ -82,6 +83,7 @@ fn transmit_receive_message_one_byte_one_frame() {
             subject,
             source: Some(8.try_into().unwrap()),
         }),
+        loopback: false,
         payload: vec![0x27],
     };
     check_loopback::<_, _, 1472>(
@@ -109,6 +111,7 @@ fn transmit_receive_request_one_byte_one_frame() {
             source: 8.try_into().unwrap(),
             destination: 993.try_into().unwrap(),
         }),
+        loopback: false,
         payload: vec![0x27],
     };
     check_loopback::<_, _, 1472>(
@@ -136,6 +139,7 @@ fn transmit_receive_response_one_byte_one_frame() {
             source: 8.try_into().unwrap(),
             destination: 993.try_into().unwrap(),
         }),
+        loopback: false,
         payload: vec![0x27],
     };
     check_loopback::<_, _, 1472>(

--- a/canadensis_udp/tests/loopback_transmit_receive.rs
+++ b/canadensis_udp/tests/loopback_transmit_receive.rs
@@ -154,7 +154,7 @@ fn transmit_receive_response_one_byte_one_frame() {
 }
 
 type TestUdpReceiver<const MTU: usize> = UdpReceiver<
-    Microseconds64,
+    SystemClock,
     SessionDynamicMap<Microseconds64, UdpNodeId, UdpTransferId, UdpSessionData>,
     StdUdpSocket,
     MTU,
@@ -212,7 +212,7 @@ fn check_loopback<S, U, const MTU: usize>(
 
         let timeout = Instant::now() + Duration::from_secs(1);
         loop {
-            match receiver.receive(clock.now(), &mut receive_socket) {
+            match receiver.receive(clock, &mut receive_socket) {
                 Ok(Some(received_transfer)) => {
                     assert_eq!(&received_transfer.payload, &transfer.payload);
                     break;
@@ -268,7 +268,7 @@ fn send_and_expect_not_received<const MTU: usize>(
 
         let timeout = Instant::now() + Duration::from_millis(100);
         loop {
-            match receiver.receive(clock.now(), receive_socket) {
+            match receiver.receive(clock, receive_socket) {
                 Ok(Some(received_transfer)) => {
                     panic!(
                         "Received transfer when not subscribed: {:#?}",


### PR DESCRIPTION
This is a basic implementation of loopback transfers and frames for Cyphal/CAN.

The timestamp of a loopback frame is taken from the `now` timestamp passed to the driver's transmit function. That may or may not be accurate enough for time synchronization.

To receive a loopback transfer, the node needs to have a corresponding subscription. That means that it will also receive transfers on the same port from all other nodes. Sometimes we don't want that. In the future, there should be a way to subscribe to loopback transfers only.

This includes one test that uses message transfers (not requests) and tests the node and CAN transport code.

Closes #11