### PR TITLE
Fix half no_std compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `canadensis_data_types`: Added default-features = false to half dependency to fix no_std compatibility
+- `canadensis`: Added default-features = false to half dependency to fix no_std compatibility
+- `canadensis_macro`: Added default-features = false to half dependency to fix no_std compatibility
 
 ## [canadensis_codegen_rust-v0.4.2](https://github.com/samcrow/canadensis/releases/tag/canadensis_codegen_rust-v0.4.2) - 2023-09-05
 

--- a/canadensis/Cargo.toml
+++ b/canadensis/Cargo.toml
@@ -13,7 +13,7 @@ description = "A Cyphal implementation: Node types and re-exports from some othe
 fallible_collections = "0.4.0"
 hash32 = "0.2.1"
 heapless = "0.7.0"
-half = "2.2"
+half = { version = "2.2", default-features = false }
 log = "0.4"
 
 # Depends on most other canadensis crates that are not transport-specific

--- a/canadensis_macro/Cargo.toml
+++ b/canadensis_macro/Cargo.toml
@@ -29,7 +29,7 @@ path = "../canadensis_codegen_rust"
 
 # These dev-dependencies are required by the generated code
 [dev-dependencies]
-half = "2.2"
+half = { version = "2.2", default-features = false }
 heapless = "0.7.7"
 zerocopy = "0.6.0"
 memoffset = "0.8.0"


### PR DESCRIPTION
It seems that not all crates were fixed in https://github.com/samcrow/canadensis/commit/9004e2ef0ea701ab5a4c1e0216512f0ecb75cdac

Added `default-features = false` for the rest of `half` dependencies