### PR TITLE
Implement support for `defmt`

### DIFF
--- a/canadensis/Cargo.toml
+++ b/canadensis/Cargo.toml
@@ -11,10 +11,11 @@ description = "A Cyphal implementation: Node types and re-exports from some othe
 
 [dependencies]
 crc-any = { version = "2.4.0", default-features = false  }
+defmt = { version = "1", optional = true }
 fallible_collections = "0.5.1"
 heapless = "0.9.1"
 half = { version = "2.6.0", default-features = false }
-log = "0.4"
+l0g = "1.0"
 num-traits = { version = "0.2.19", default-features = false }
 
 # Depends on most other canadensis crates that are not transport-specific
@@ -35,6 +36,7 @@ version = "0.5.0"
 path = "../canadensis_data_types"
 
 [dev-dependencies]
+log = "0.4"
 socketcan = { version = "3.5.0", default-features = false }
 rand = "0.9.2"
 simplelog = "0.12.0"
@@ -52,3 +54,5 @@ path = "../canadensis_serial"
 version = "0.5.0"
 path = "../canadensis_udp"
 
+[features]
+defmt = ["dep:defmt", "canadensis_core/defmt", "heapless/defmt"]

--- a/canadensis/src/anonymous.rs
+++ b/canadensis/src/anonymous.rs
@@ -138,6 +138,7 @@ where
 
 /// Errors that can occur when publishing an anonymous message
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum AnonymousPublishError<E> {
     /// The message was too long to fit into one frame
     Length,

--- a/canadensis/src/lib.rs
+++ b/canadensis/src/lib.rs
@@ -89,6 +89,25 @@ where
     }
 }
 
+#[cfg(feature = "defmt")]
+impl<T: Transport> defmt::Format for ResponseToken<T>
+where
+    T::NodeId: defmt::Format,
+    T::TransferId: defmt::Format,
+    T::Priority: defmt::Format,
+{
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "ResponseToken {{ service: {}, client: {}, transfer: {}, priority: {} }}",
+            self.service,
+            self.client,
+            self.transfer,
+            self.priority
+        )
+    }
+}
+
 /// Something that may be able to handle incoming transfers
 pub trait TransferHandler<T: Transport> {
     /// Potentially handles an incoming message transfer
@@ -514,6 +533,7 @@ pub trait Node {
 
 /// Errors that may occur when publishing a message
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum PublishError<T> {
     /// [`Node::start_publishing`](Node#tymethod.start_publishing) has not been called for this subject
     NotPublishing,
@@ -536,6 +556,7 @@ impl<T> ServiceToken<T> {
 
 /// Errors that may occur when starting to send messages or requests
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum StartSendError<E> {
     /// Memory to store the publisher was not available
     Memory(OutOfMemoryError),

--- a/canadensis/src/node/core.rs
+++ b/canadensis/src/node/core.rs
@@ -33,6 +33,7 @@ use crate::{Node, PublishError, ResponseToken, ServiceToken, StartSendError, Tra
 ///   two, or the software may behave incorrectly.
 ///
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct CoreNode<C, T, U, TR, D, const P: usize, const R: usize>
 where
     C: Clock,

--- a/canadensis/src/node/mod.rs
+++ b/canadensis/src/node/mod.rs
@@ -27,6 +27,7 @@ pub mod data_types {
 
 /// An error from a transmitter or receiver
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum NodeError<T, R> {
     /// An error from a transmitter
     Transmitter(T),

--- a/canadensis/src/publisher.rs
+++ b/canadensis/src/publisher.rs
@@ -144,4 +144,24 @@ mod fmt_impl {
                 .finish()
         }
     }
+
+    #[cfg(feature = "defmt")]
+    impl<C, T> defmt::Format for Publisher<C, T>
+    where
+        C: Clock,
+        T: Transmitter<C>,
+        <T::Transport as Transport>::TransferId: defmt::Format,
+        <T::Transport as Transport>::Priority: defmt::Format,
+        <T::Transport as Transport>::NodeId: defmt::Format,
+    {
+        fn format(&self, f: defmt::Formatter) {
+            defmt::write!(
+                f,
+                "Publisher {{ next_transfer_id: {}, timeout: {}, priority: {} }}",
+                self.next_transfer_id,
+                self.timeout,
+                self.priority
+            )
+        }
+    }
 }

--- a/canadensis/src/register.rs
+++ b/canadensis/src/register.rs
@@ -59,6 +59,7 @@ pub trait RegisterBlock {
 
 /// Information about how a register can be accessed
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Access {
     /// If this register is mutable
     ///
@@ -106,6 +107,7 @@ pub trait Register {
 
 /// Errors that can occur when attempting to write a register
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum WriteError {
     /// The type of the value, or the number of values in an array, was incorrect
     Type,
@@ -165,7 +167,7 @@ where
     fn handle_access_request(&mut self, request: &AccessRequest) -> AccessResponse {
         match str::from_utf8(&request.name.name) {
             Ok(register_name) => {
-                log::debug!("Handling access request for {}", register_name);
+                l0g::debug!("Handling access request for {}", register_name);
                 if let Some(register) = self.block.register_by_name_mut(register_name) {
                     register_handle_access(register, request)
                 } else {
@@ -195,7 +197,7 @@ where
     }
 
     fn handle_list_request(&mut self, request: &ListRequest) -> ListResponse {
-        log::debug!("Handling register list request, index {}", {
+        l0g::debug!("Handling register list request, index {}", {
             request.index
         });
         match self.block.register_by_index(request.index.into()) {
@@ -262,7 +264,7 @@ where
                     let response = self.handle_access_request(&request);
                     let status = node.send_response(token, milliseconds(1000), &response);
                     if status.is_err() {
-                        log::warn!("Out of memory when sending register access response");
+                        l0g::warn!("Out of memory when sending register access response");
                     }
                     true
                 } else {
@@ -274,7 +276,7 @@ where
                     let response = self.handle_list_request(&request);
                     let status = node.send_response(token, milliseconds(1000), &response);
                     if status.is_err() {
-                        log::warn!("Out of memory when sending register list response");
+                        l0g::warn!("Out of memory when sending register list response");
                     }
                     true
                 } else {

--- a/canadensis/src/register/basic.rs
+++ b/canadensis/src/register/basic.rs
@@ -22,6 +22,7 @@ use half::f16;
 
 /// A register containing its name, value, and mutable/persistent flags
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SimpleRegister<T> {
     name: &'static str,
     access: Access,
@@ -143,6 +144,22 @@ where
             .field("access", &self.access)
             .field("value", &self.value)
             .finish()
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl<T, V> defmt::Format for ValidatedRegister<T, V>
+where
+    T: defmt::Format,
+{
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "ValidatedRegister {{ name: \"{}\", access: {}, value: {} }}",
+            self.name,
+            self.access,
+            self.value
+        )
     }
 }
 
@@ -352,6 +369,7 @@ register_primitive_array!(f64, Real64);
 
 /// A string value for a register
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct RegisterString(pub heapless::Vec<u8, 256>);
 
 impl RegisterType for RegisterString {
@@ -395,6 +413,7 @@ impl TryFrom<&str> for RegisterString {
 
 /// An unstructured byte array value for a register
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Unstructured(pub heapless::Vec<u8, 256>);
 
 impl RegisterType for Unstructured {
@@ -476,12 +495,14 @@ impl<const N: usize> RegisterType for [bool; N] {
 
 /// An error indicating that a provided value was too long
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct LengthError(());
 
 /// A non-mutable, persistent register that holds a fixed string value
 ///
 /// This is useful for registers that provide information and cannot be changed.
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct FixedStringRegister {
     /// Register name, not empty, 256 bytes or shorter
     name: &'static str,

--- a/canadensis/src/requester.rs
+++ b/canadensis/src/requester.rs
@@ -203,4 +203,25 @@ mod fmt_impl {
                 .finish()
         }
     }
+
+    #[cfg(feature = "defmt")]
+    impl<C, T, R> defmt::Format for Requester<C, T, R>
+    where
+        C: Clock,
+        T: Transmitter<C>,
+        <T::Transport as Transport>::TransferId: defmt::Format,
+        <T::Transport as Transport>::Priority: defmt::Format,
+        <T::Transport as Transport>::NodeId: defmt::Format,
+        R: defmt::Format,
+    {
+        fn format(&self, f: defmt::Formatter) {
+            defmt::write!(
+                f,
+                "Requester {{ priority: {}, timeout: {}, transfer_ids: {} }}",
+                self.priority,
+                self.timeout,
+                self.transfer_ids
+            )
+        }
+    }
 }

--- a/canadensis/src/service/pnp/mod.rs
+++ b/canadensis/src/service/pnp/mod.rs
@@ -117,6 +117,7 @@ where
 
 /// Error type returned by [`PnpClientService::new`].
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum NewError<N: Node> {
     /// The client could not subscribe to the message subject due to a receiver error.
     Subscribe(<N::Receiver as Receiver<N::Clock>>::Error),

--- a/canadensis/src/service/pnp/server.rs
+++ b/canadensis/src/service/pnp/server.rs
@@ -15,6 +15,7 @@ use num_traits::Bounded;
 
 /// Defines the states of assignment
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Assignment {
     /// No assignment
     Unassigned,

--- a/canadensis/src/service/register_server.rs
+++ b/canadensis/src/service/register_server.rs
@@ -14,7 +14,7 @@ use canadensis_data_types::uavcan::time::synchronized_timestamp_1_0::Synchronize
 use canadensis_encoding::Deserialize;
 use core::marker::PhantomData;
 use core::str;
-use log::{debug, warn};
+use l0g::{debug, warn};
 
 /// A service that responds to `uavcan.register.List` and `uavcan.register.Access`
 pub struct RegisterServerService<N: Node, B: RegisterBlock> {
@@ -101,6 +101,7 @@ where
                             }
                         }
                     };
+                    #[allow(unused_variables)]
                     if let Err(err) = node.send_response(token, milliseconds(1000), &response) {
                         warn!("Failed to send response: {:?}", err);
                     }
@@ -132,6 +133,7 @@ where
                             }
                         }
                     };
+                    #[allow(unused_variables)]
                     if let Err(err) = node.send_response(token, milliseconds(1000), &response) {
                         warn!("Failed to send response: {:?}", err);
                     }

--- a/canadensis_bxcan/Cargo.toml
+++ b/canadensis_bxcan/Cargo.toml
@@ -13,8 +13,8 @@ description = "Bridge between Canadensis and the BXCAN peripherals found in some
 
 [dependencies]
 bxcan = "0.8.0"
+defmt = { version = "1.0", optional = true }
 nb = "1.0.0"
-log = "0.4"
 fallible_collections = "0.5.1"
 heapless = "0.9.1"
 cortex-m = "0.7.3"

--- a/canadensis_bxcan/src/lib.rs
+++ b/canadensis_bxcan/src/lib.rs
@@ -18,7 +18,6 @@ extern crate canadensis_pnp_client;
 extern crate cortex_m;
 extern crate fallible_collections;
 extern crate heapless;
-extern crate log;
 extern crate nb;
 
 pub mod pnp;
@@ -332,4 +331,5 @@ fn bxcan_frame_to_cyphal(
 
 /// An error indicating that a frame did not have the correct format for use with Cyphal
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct InvalidFrameFormat;

--- a/canadensis_can/Cargo.toml
+++ b/canadensis_can/Cargo.toml
@@ -11,9 +11,10 @@ description = "A Cyphal implementation: Cyphal/CAN (CAN and CAN FD) transport la
 
 [dependencies]
 bitvec = { version = "1.0.1", default-features = false }
+defmt = { version = "1.0", optional = true, features = ["alloc"] }
 fallible_collections = "0.5.1"
 heapless = "0.9.1"
-log = "0.4"
+l0g = "1.0"
 num-traits = { version = "0.2.19", default-features = false }
 
 [dependencies.canadensis_core]
@@ -27,3 +28,4 @@ path = "../canadensis_filter_config"
 [features]
 # The can-fd feature increases the maximum frame capacity and maximum MTU from 8 to 64 bytes
 can-fd = []
+defmt = ["dep:defmt", "canadensis_core/defmt", "heapless/defmt"]

--- a/canadensis_can/src/data.rs
+++ b/canadensis_can/src/data.rs
@@ -21,6 +21,13 @@ impl fmt::Debug for CanId {
     }
 }
 
+#[cfg(feature = "defmt")]
+impl defmt::Format for CanId {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "CanId({:#010x})", self.0)
+    }
+}
+
 impl TryFrom<u32> for CanId {
     type Error = InvalidValue;
 
@@ -42,6 +49,7 @@ impl From<CanId> for u32 {
 
 /// Allowed maximum transmission unit (MTU) values
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Mtu {
     /// 8 bytes, for standard CAN
     Can8 = 8,
@@ -83,6 +91,7 @@ pub const FRAME_CAPACITY: usize = 8;
 /// This is useful for time synchronization.
 ///
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Frame {
     /// For RX frames: reception timestamp.
     /// For TX frames: transmission deadline.

--- a/canadensis_can/src/lib.rs
+++ b/canadensis_can/src/lib.rs
@@ -13,7 +13,6 @@ extern crate canadensis_core;
 extern crate canadensis_filter_config;
 extern crate fallible_collections;
 extern crate heapless;
-extern crate log;
 
 pub use crate::data::*;
 pub use crate::rx::CanReceiver;
@@ -72,6 +71,7 @@ fn calculate_frame_stats(payload_length: usize, mtu: usize) -> FrameStats {
 
 /// Information about how to fit a transfer payload into frames
 #[derive(Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 struct FrameStats {
     /// The total number of frames
     pub frames: usize,

--- a/canadensis_can/src/queue/array_queue.rs
+++ b/canadensis_can/src/queue/array_queue.rs
@@ -9,6 +9,7 @@ use core::ptr;
 /// `N` is the maximum number of frames that the queue can hold. This should be at least as large
 /// as the number of frames required for the largest outgoing transfer that will be sent.
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ArrayQueue<const N: usize> {
     /// The frames in this queue
     ///

--- a/canadensis_can/src/redundant/deduplicator.rs
+++ b/canadensis_can/src/redundant/deduplicator.rs
@@ -21,6 +21,7 @@ use canadensis_core::time::{MicrosecondDuration32, Microseconds32};
 /// For more explanation, see [the comments in pycyphal](https://github.com/OpenCyphal/pycyphal/blob/87c27a978119d24ac77c9a7f2d6f289846ac96fd/pyuavcan/transport/redundant/__init__.py).
 ///
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Deduplicator<const N: usize> {
     /// The state for each transport
     states: [TransportState; N],
@@ -85,6 +86,7 @@ impl<const N: usize> Deduplicator<N> {
 
 /// Information about a transport
 #[derive(Debug, Default, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 struct TransportState {
     last_frame_time: Option<Microseconds32>,
 }

--- a/canadensis_can/src/redundant/redundant_queue.rs
+++ b/canadensis_can/src/redundant/redundant_queue.rs
@@ -103,6 +103,7 @@ where
 
 /// An error from a DoubleRedundantQueueDriver
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum RedundantError<E0, E1> {
     /// An error from driver 0
     Driver0(E0),

--- a/canadensis_can/src/rx.rs
+++ b/canadensis_can/src/rx.rs
@@ -27,6 +27,7 @@ use canadensis_core::{
 
 /// Handles subscriptions and assembles incoming frames into transfers
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct CanReceiver<C, D> {
     /// Subscriptions for messages
     subscriptions_message: Vec<Subscription>,
@@ -278,7 +279,7 @@ where
             Some(data) => data,
             None => {
                 // Can't use this frame
-                log::debug!("Frame failed sanity checks, ignoring");
+                l0g::debug!("Frame failed sanity checks, ignoring");
                 self.increment_error_count();
                 return Ok(None);
             }
@@ -322,7 +323,7 @@ where
                 }
                 Ok(None) => Ok(None),
                 Err(e) => {
-                    log::info!("Receiver accept error {:?}", e);
+                    l0g::info!("Receiver accept error {:?}", e);
                     self.increment_error_count();
                     match e {
                         SubscriptionError::Session(SessionError::Memory(e))
@@ -353,7 +354,7 @@ where
             if message_header.source.is_none() {
                 // Anonymous message transfers must always fit into one frame
                 if !(tail_byte.toggle && tail_byte.start && tail_byte.end) {
-                    log::debug!("Anonymous multi-frame transfer, ignoring");
+                    l0g::debug!("Anonymous multi-frame transfer, ignoring");
                     return None;
                 }
             }
@@ -436,6 +437,7 @@ where
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum CanIdParseError {
     /// Reserved bit 23 was set
     Bit23Set,
@@ -634,6 +636,7 @@ impl TailByte {
 
 /// Types of transfers
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 enum TransferKind {
     Message,
     Request,

--- a/canadensis_can/src/rx/buildup.rs
+++ b/canadensis_can/src/rx/buildup.rs
@@ -8,6 +8,7 @@ use canadensis_core::OutOfMemoryError;
 
 /// Reassembles frames into a transfer
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Buildup {
     /// The number of frames processed
     frames: usize,
@@ -94,7 +95,7 @@ impl Buildup {
                 let data = mem::take(&mut self.transfer);
                 Ok(Some(data))
             } else {
-                log::debug!("Incorrect transfer CRC");
+                l0g::debug!("Incorrect transfer CRC");
                 Err(BuildupError::Crc)
             }
         } else {
@@ -105,6 +106,7 @@ impl Buildup {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum BuildupError {
     OutOfMemory,
     Crc,

--- a/canadensis_can/src/rx/session.rs
+++ b/canadensis_can/src/rx/session.rs
@@ -10,6 +10,7 @@ use fallible_collections::FallibleBox;
 
 /// A receive session, associated with a particular port ID and source node
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Session {
     /// Timestamp of the first frame received in this transfer
     transfer_timestamp: Microseconds32,
@@ -59,7 +60,7 @@ impl Session {
         frame_header: Header,
     ) -> Result<Option<Transfer<Vec<u8>>>, SessionError> {
         if frame.loopback() != self.loopback {
-            log::info!("Frame loopback flag does not match, ignoring");
+            l0g::info!("Frame loopback flag does not match, ignoring");
             return Ok(None);
         }
         // This frame looks OK. Do the reassembly.
@@ -93,6 +94,7 @@ impl Session {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SessionError {
     /// Reassembly failed because of an unexpected frame
     Buildup,

--- a/canadensis_can/src/rx/subscription.rs
+++ b/canadensis_can/src/rx/subscription.rs
@@ -18,6 +18,7 @@ const NUM_NODE_IDS: usize = CanNodeId::MAX.to_u8() as usize + 1;
 /// and Buildup layers are not aware of transfer-IDs and do not check or track them.
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 struct SessionState {
     expected_transfer_id: CanTransferId,
     last_transfer_time: Option<Microseconds32>,
@@ -27,6 +28,7 @@ struct SessionState {
 /// Transfer subscription state. The application can register its interest in a particular kind of data exchanged
 /// over the bus by creating such subscription objects. Frames that carry data for which there is no active
 /// subscription will be silently dropped by the library.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Subscription {
     /// Transfer-ID timeout for this subscription
     ///
@@ -168,7 +170,7 @@ impl Subscription {
         let slot: &mut Option<Box<Session>> = &mut self.states.get_mut(source).session;
         let session: &mut Box<Session> = match slot {
             Some(session) => {
-                log::debug!(
+                l0g::debug!(
                     "Using existing session with transfer ID {:?} for port {:?}",
                     tail.transfer_id,
                     self.port_id,
@@ -181,7 +183,7 @@ impl Subscription {
                     // Not the start of a transfer, so it must be a fragment of some other transfer.
                     return Err(SubscriptionError::NotStart);
                 }
-                log::debug!(
+                l0g::debug!(
                     "Creating new session for transfer ID {:?} on port {:?}",
                     tail.transfer_id,
                     self.port_id
@@ -249,6 +251,7 @@ impl Subscription {
 
 /// Errors that a subscription may encounter
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SubscriptionError {
     /// Received a frame with no corresponding session, but its start bit was not set
     NotStart,
@@ -275,6 +278,7 @@ impl From<TryReserveError> for SubscriptionError {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 struct SessionStates {
     states: [SessionState; NUM_NODE_IDS],
 }

--- a/canadensis_can/src/types.rs
+++ b/canadensis_can/src/types.rs
@@ -27,6 +27,7 @@ const VALID_NODE_IDS: RangeInclusive<u8> = 0..=127;
 /// Valid node IDs are in the range 0..=127 (7 bits). IDs 126 and 127 are reserved for diagnostic
 /// and debugging tools.
 #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct CanNodeId(u8);
 
 impl CanNodeId {
@@ -129,6 +130,7 @@ const VALID_TRANSFER_IDS: RangeInclusive<u8> = 0..=31;
 
 /// Transfer ID, 5 bits, in range 0..=31
 #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct CanTransferId(u8);
 
 impl CanTransferId {
@@ -204,6 +206,7 @@ impl Default for CanTransferId {
 
 /// CAN transport errors
 #[derive(Debug, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error<E> {
     /// Memory allocation failed
     Memory(OutOfMemoryError),

--- a/canadensis_core/Cargo.toml
+++ b/canadensis_core/Cargo.toml
@@ -10,9 +10,12 @@ license = "MIT OR Apache-2.0"
 description = "A Cyphal implementation: Common definitions"
 
 [dependencies]
+defmt = { version = "1.0", optional = true }
 fugit = "0.3.7"
 fallible_collections = "0.5.1"
 heapless = "0.9.1"
-log = "0.4.14"
 nb = "1.0.0"
 num-traits = { version = "0.2.19", default-features = false }
+
+[features]
+defmt = ["dep:defmt", "fugit/defmt", "nb/defmt-0-3"]

--- a/canadensis_core/src/crc.rs
+++ b/canadensis_core/src/crc.rs
@@ -5,6 +5,7 @@
 ///
 /// Internally, this uses CRC-32C.
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct CrcTracker {
     /// CRC of all bytes before last_four_bytes
     crc: Crc32c,
@@ -103,6 +104,7 @@ const CRC32_REFLECTED_POLY: u32 = 0x82f6_3b78;
 ///
 /// The Cyphal/Serial and Cyphal/UDP transfer CRC uses this.
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Crc32c {
     value: u32,
 }
@@ -151,6 +153,7 @@ const CRC16_POLY: u16 = 0x1021;
 ///
 /// The Cyphal/CAN transfer CRC and Cyphal/Serial and Cyphal/UDP header CRC use this.
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Crc16CcittFalse {
     value: u16,
 }

--- a/canadensis_core/src/error.rs
+++ b/canadensis_core/src/error.rs
@@ -6,6 +6,7 @@ use fallible_collections::TryReserveError;
 
 /// An error indicating that memory could not be allocated
 #[derive(Debug, Eq, PartialEq, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct OutOfMemoryError;
 
 impl From<TryReserveError> for OutOfMemoryError {
@@ -16,6 +17,7 @@ impl From<TryReserveError> for OutOfMemoryError {
 
 /// An error that may occur when subscribing to a service
 #[derive(Debug, Eq, PartialEq, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ServiceSubscribeError<E> {
     /// Can't subscribe to a service because this is an anonymous node
     Anonymous,

--- a/canadensis_core/src/lib.rs
+++ b/canadensis_core/src/lib.rs
@@ -9,7 +9,6 @@ extern crate alloc;
 extern crate fallible_collections;
 extern crate fugit;
 extern crate heapless;
-extern crate log;
 pub extern crate nb;
 
 pub mod crc;
@@ -27,6 +26,7 @@ use core::str::FromStr;
 
 /// An error indicating that an unacceptable integer was provided to a TryFrom implementation
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct InvalidValue;
 pub use crate::error::{OutOfMemoryError, ServiceSubscribeError};
 
@@ -35,6 +35,7 @@ const VALID_SUBJECT_IDS: RangeInclusive<u16> = 0..=8191;
 
 /// Subject ID, in range 0..=8191
 #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SubjectId(u16);
 
 impl SubjectId {
@@ -98,6 +99,7 @@ const VALID_SERVICE_IDS: RangeInclusive<u16> = 0..=511;
 
 /// Service ID, in range 0..=511
 #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ServiceId(u16);
 
 impl ServiceId {
@@ -150,6 +152,7 @@ impl From<ServiceId> for usize {
 
 /// A value that can represent a service ID (0..=511) or a subject ID (0..=8192)
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PortId(u16);
 
 impl From<SubjectId> for PortId {
@@ -182,6 +185,7 @@ impl TryFrom<PortId> for ServiceId {
 ///
 /// Transports can define their own priority levels with more detail.
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Priority {
     /// The bus designer can ignore these messages when calculating bus load since they should
     /// only be sent when a total system failure has occurred. For example, a self-destruct message

--- a/canadensis_core/src/session.rs
+++ b/canadensis_core/src/session.rs
@@ -51,6 +51,7 @@ pub trait SessionTracker<N, T, D> {
 /// If a session for a specific port and node ID does not exist, this node has never received a
 /// transfer.
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Session<T, D> {
     /// This node is in the process of reassembling a transfer
     Active(ActiveSession<T, D>),
@@ -65,6 +66,7 @@ pub enum Session<T, D> {
 
 /// A session with an incoming transfer undergoing reassembly
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ActiveSession<T, D> {
     /// The timestamp of the first frame in this transfer
     pub time: Microseconds32,

--- a/canadensis_core/src/subscription.rs
+++ b/canadensis_core/src/subscription.rs
@@ -263,6 +263,7 @@ impl<S> Default for DynamicSubscriptionManager<S> {
 
 /// Information about something that a receiver/node is subscribed to
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Subscription {
     /// A message subscription, for messages with the specified subject ID
     Message(SubjectId),

--- a/canadensis_core/src/transfer.rs
+++ b/canadensis_core/src/transfer.rs
@@ -8,6 +8,7 @@ use crate::{PortId, ServiceId, SubjectId};
 use core::fmt::{Debug, Formatter};
 
 /// The header of a message transfer
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct MessageHeader<T: Transport + ?Sized> {
     /// For RX transfers: the time when the first frame was received
     /// For TX transfers: the transmission deadline for all frames
@@ -68,6 +69,7 @@ where
 }
 
 /// The header of a service transfer
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ServiceHeader<T: Transport + ?Sized> {
     /// For RX transfers: the time when the first frame was received
     /// For TX transfers: the transmission deadline for all frames
@@ -133,6 +135,7 @@ where
 }
 
 /// Header fields for a message, request, or response
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Header<T: Transport + ?Sized> {
     /// A message header
     Message(MessageHeader<T>),
@@ -287,6 +290,25 @@ where
     }
 }
 
+#[cfg(feature = "defmt")]
+impl<A, T: Transport + ?Sized> defmt::Format for Transfer<A, T>
+where
+    A: defmt::Format,
+    <T as Transport>::NodeId: defmt::Format,
+    <T as Transport>::Priority: defmt::Format,
+    <T as Transport>::TransferId: defmt::Format,
+{
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "Transfer {{ header: {}, loopback: {}, payload: {} }}",
+            self.header,
+            self.loopback,
+            self.payload
+        )
+    }
+}
+
 impl<A, T: Transport + ?Sized> PartialEq for Transfer<A, T>
 where
     A: PartialEq,
@@ -349,6 +371,25 @@ where
     }
 }
 
+#[cfg(feature = "defmt")]
+impl<A, T: Transport + ?Sized> defmt::Format for MessageTransfer<A, T>
+where
+    A: defmt::Format,
+    <T as Transport>::NodeId: defmt::Format,
+    <T as Transport>::Priority: defmt::Format,
+    <T as Transport>::TransferId: defmt::Format,
+{
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "Transfer {{ header: {}, loopback: {}, payload: {} }}",
+            self.header,
+            self.loopback,
+            self.payload
+        )
+    }
+}
+
 impl<A, T: Transport + ?Sized> PartialEq for MessageTransfer<A, T>
 where
     A: PartialEq,
@@ -393,6 +434,25 @@ where
             .field("loopback", &self.loopback)
             .field("payload", &self.payload)
             .finish()
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl<A, T: Transport + ?Sized> defmt::Format for ServiceTransfer<A, T>
+where
+    A: defmt::Format,
+    <T as Transport>::NodeId: defmt::Format,
+    <T as Transport>::Priority: defmt::Format,
+    <T as Transport>::TransferId: defmt::Format,
+{
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "Transfer {{ header: {}, loopback: {}, payload: {} }}",
+            self.header,
+            self.loopback,
+            self.payload
+        )
     }
 }
 

--- a/canadensis_data_types/Cargo.toml
+++ b/canadensis_data_types/Cargo.toml
@@ -12,6 +12,7 @@ description = "Automatically generated types for all Cyphal public regulated dat
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+defmt = { version = "1.0", optional = true }
 half = { version = "2.6.0", default-features = false, features = ["zerocopy"] }
 heapless = "0.9.1"
 zerocopy = "0.8.26"

--- a/canadensis_data_types/src/optimized.rs
+++ b/canadensis_data_types/src/optimized.rs
@@ -7,6 +7,7 @@ const SUBJECT_ID_SPARSE_LIST_DISCRIMINANT: u8 = 1;
 /// A fixed-capacity list of subject IDs that is compatible with
 /// `uavcan.node.port.SubjectIDList.1.0`
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SubjectIdList<const N: usize>(pub Vec<SubjectId, N>);
 
 impl<const N: usize> SubjectIdList<N> {

--- a/canadensis_encoding/Cargo.toml
+++ b/canadensis_encoding/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT OR Apache-2.0"
 description = "A Cyphal implementation: Transfer encoding and decoding"
 
 [dependencies]
+defmt = { version = "1.0", optional = true }
 half = { version = "2.6.0", default-features = false }
 zerocopy = "0.8.26"
 

--- a/canadensis_encoding/src/bits.rs
+++ b/canadensis_encoding/src/bits.rs
@@ -9,6 +9,7 @@ use core::fmt;
 /// Because the const generics feature is incomplete, the integer generic parameter is a number
 /// of bytes (= 8 bits), not a number of bits. The functions still use bit indexes.
 #[derive(Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct BitArray<const BYTES: usize> {
     bytes: [u8; BYTES],
     bit_length: usize,

--- a/canadensis_encoding/src/cursor/deserialize.rs
+++ b/canadensis_encoding/src/cursor/deserialize.rs
@@ -13,6 +13,7 @@ use crate::{Deserialize, DeserializeError};
 /// Functions that read values will return zero when reading beyond the end of the bytes,
 /// in accordance with the implicit zero extension rule (specification section 3.7.1.5)
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ReadCursor<'b> {
     /// The bytes available to read from
     ///

--- a/canadensis_encoding/src/lib.rs
+++ b/canadensis_encoding/src/lib.rs
@@ -97,6 +97,7 @@ pub trait Response {}
 /// Errors that can occur when deserializing
 #[non_exhaustive]
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DeserializeError {
     /// A variable-length array length field was greater than the maximum allowed length
     ArrayLength,

--- a/canadensis_filter_config/Cargo.toml
+++ b/canadensis_filter_config/Cargo.toml
@@ -16,3 +16,4 @@ name = "optimize_filters"
 path = "bin/optimize_filters.rs"
 
 [dependencies]
+defmt = { version = "1.0", optional = true }

--- a/canadensis_filter_config/src/lib.rs
+++ b/canadensis_filter_config/src/lib.rs
@@ -131,10 +131,30 @@ mod debug_impl {
         }
     }
 
+    #[cfg(feature = "defmt")]
+    impl defmt::Format for Filter {
+        fn format(&self, f: defmt::Formatter) {
+            defmt::write!(
+                f,
+                "Filter {{ valid: {}, mask: {}, id: {}",
+                self.is_valid(),
+                DebugHex(self.mask()),
+                DebugHex(self.id())
+            )
+        }
+    }
+
     struct DebugHex(u32);
     impl Debug for DebugHex {
         fn fmt(&self, f: &mut Formatter<'_>) -> Result {
             write!(f, "{:#010x}", self.0)
+        }
+    }
+
+    #[cfg(feature = "defmt")]
+    impl defmt::Format for DebugHex {
+        fn format(&self, f: defmt::Formatter) {
+            defmt::write!(f, "{:#010x}", self.0)
         }
     }
 }

--- a/canadensis_header/Cargo.toml
+++ b/canadensis_header/Cargo.toml
@@ -9,5 +9,9 @@ description = "The frame header format used by Cyphal/Serial and Cyphal/UDP"
 
 [dependencies]
 canadensis_core = { version = "0.5.1", path = "../canadensis_core" }
+defmt = { version = "1.0", optional = true }
 num-traits = { version = "0.2.19", default-features = false }
 zerocopy = { version = "0.8.26", features = ["derive"] }
+
+[features]
+defmt = ["dep:defmt", "canadensis_core/defmt"]

--- a/canadensis_header/src/lib.rs
+++ b/canadensis_header/src/lib.rs
@@ -43,6 +43,25 @@ pub struct RawHeader {
     header_checksum: U16<BigEndian>,
 }
 
+#[cfg(feature = "defmt")]
+impl defmt::Format for RawHeader {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "RawHeader {{ version: {}, priority: {}, source_node_id: {}, destination_node_id: {}, data_specifier: {}, transfer_id: {}, frame_index_eot: {}, data: {}, header_checksum: {} }}",
+            self.version,
+            self.priority,
+            self.source_node_id.get(),
+            self.destination_node_id.get(),
+            self.data_specifier.get(),
+            self.transfer_id.get(),
+            self.frame_index_eot.get(),
+            self.data.get(),
+            self.header_checksum.get()
+        )
+    }
+}
+
 impl RawHeader {
     /// Returns true if this is the last frame in a transfer
     pub fn is_last_frame(&self) -> bool {
@@ -79,6 +98,7 @@ const DATA_SPEC_SERVICE_ID_MASK: u16 =
 /// [This post](https://forum.opencyphal.org/t/cyphal-udp-architectural-issues-caused-by-the-dependency-between-the-nodes-ip-address-and-its-identity/1765/60)
 /// specifies the header format.
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Header {
     /// Priority level
     pub priority: Priority,
@@ -287,6 +307,7 @@ where
 
 /// The message/service, subject ID/service ID, source, and destination of a frame
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DataSpecifier {
     Subject {
         from: Option<NodeId16>,
@@ -333,6 +354,7 @@ fn check_node_id(id: u16) -> Result<Option<NodeId16>, InvalidValue> {
 ///
 /// This allows all u16 values except 65535, which is reserved for anonymous transfers
 #[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct NodeId16(u16);
 
 const NODE_ID_RESERVED_ANONYMOUS_OR_BROADCAST: u16 = 0xffff;
@@ -379,6 +401,7 @@ impl Bounded for NodeId16 {
 ///
 /// This is just a `u64`.
 #[derive(Default, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct TransferId64(u64);
 
 impl TransferId for TransferId64 {

--- a/canadensis_serial/Cargo.toml
+++ b/canadensis_serial/Cargo.toml
@@ -10,10 +10,11 @@ description = "A Cyphal implementation: Cyphal/Serial transport"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+defmt = { version = "1.0", optional = true }
 zerocopy = "0.8.26"
 heapless = "0.9.1"
 fallible_collections = "0.5.1"
-log = "0.4.14"
+l0g = "1.0"
 
 [dependencies.canadensis_core]
 version = "0.5.1"
@@ -21,3 +22,6 @@ path = "../canadensis_core"
 [dependencies.canadensis_header]
 version = "0.5.0"
 path = "../canadensis_header"
+
+[features]
+defmt = ["dep:defmt", "canadensis_core/defmt"]

--- a/canadensis_serial/src/cobs.rs
+++ b/canadensis_serial/src/cobs.rs
@@ -98,6 +98,7 @@ pub fn escaped_size(raw_size: usize) -> usize {
 
 /// An error that occurs if the unescaper encounters a zero byte
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DecodeZeroError;
 
 #[cfg(test)]

--- a/canadensis_serial/src/lib.rs
+++ b/canadensis_serial/src/lib.rs
@@ -5,7 +5,6 @@ extern crate canadensis_core;
 extern crate canadensis_header;
 extern crate fallible_collections;
 extern crate heapless;
-extern crate log;
 extern crate zerocopy;
 
 use canadensis_core::crc::Crc32c;
@@ -52,6 +51,7 @@ fn make_payload_crc(payload: &[u8]) -> u32 {
 
 /// Serial transport errors
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error<E> {
     /// Memory allocation failed
     Memory(OutOfMemoryError),

--- a/canadensis_serial/src/rx.rs
+++ b/canadensis_serial/src/rx.rs
@@ -79,7 +79,7 @@ where
             State::BetweenTransfers => {
                 if byte != 0 {
                     // Start decoding
-                    log::debug!("Starting frame");
+                    l0g::debug!("Starting frame");
                     let mut unescaper = Unescaper::new();
                     match unescaper.accept(byte) {
                         Ok(Some(byte)) => {
@@ -133,13 +133,14 @@ where
                                         }
                                     } else {
                                         // Not interested in this transfer
-                                        log::debug!("Got header, but not subscribed");
+                                        l0g::debug!("Got header, but not subscribed");
                                         State::Idle
                                     }
                                 }
+                                #[allow(unused_variables)]
                                 Err(e) => {
                                     // Invalid header CRC or format
-                                    log::debug!("Header format or CRC invalid: {:?}", e);
+                                    l0g::debug!("Header format or CRC invalid: {:?}", e);
                                     State::Idle
                                 }
                             }
@@ -153,7 +154,7 @@ where
                         State::Header { unescaper, header }
                     }
                     Err(_) => {
-                        log::warn!("Unexpected zero byte in Header state");
+                        l0g::warn!("Unexpected zero byte in Header state");
                         State::Idle
                     }
                 }
@@ -188,7 +189,7 @@ where
                         }
                     }
                     Err(_) => {
-                        log::debug!("Got a zero (end delimiter)");
+                        l0g::debug!("Got a zero (end delimiter)");
                         self.state = State::BetweenTransfers;
                         // Check and finish the transfer
                         return Ok(self.complete_transfer(header, payload, crc));
@@ -371,7 +372,7 @@ where
         crc: CrcTracker,
     ) -> Option<Transfer<Vec<u8>, SerialTransport>> {
         if !crc.correct() {
-            log::debug!("Dropping transfer due to incorrect transfer CRC");
+            l0g::debug!("Dropping transfer due to incorrect transfer CRC");
             return None;
         }
         // Record that this transfer was received
@@ -394,7 +395,7 @@ where
             })
         } else {
             // The subscription was removed while receiving the transfer
-            log::debug!("No matching subscription for header");
+            l0g::debug!("No matching subscription for header");
             None
         }
     }

--- a/canadensis_udp/Cargo.toml
+++ b/canadensis_udp/Cargo.toml
@@ -8,9 +8,10 @@ keywords = ["uavcan", "cyphal"]
 description = "A Cyphal implementation: Cyphal/UDP transport"
 
 [dependencies]
+defmt = { version = "1.0", optional = true, features = ["alloc"] }
 heapless = "0.9.1"
 zerocopy = "0.8.26"
-log = "0.4.14"
+l0g = "1.0"
 nb = "1.0.0"
 
 [dependencies.socket2]
@@ -25,6 +26,7 @@ version = "0.5.0"
 path = "../canadensis_header"
 
 [dev-dependencies]
+log = "0.4.14"
 simplelog = "0.12.0"
 
 [dev-dependencies.canadensis_linux]
@@ -33,3 +35,4 @@ path = "../canadensis_linux"
 [features]
 default = ["std"]
 std = ["socket2"]
+defmt = ["dep:defmt", "canadensis_header/defmt"]

--- a/canadensis_udp/src/lib.rs
+++ b/canadensis_udp/src/lib.rs
@@ -27,7 +27,6 @@ extern crate alloc;
 extern crate canadensis_core;
 extern crate canadensis_header;
 extern crate heapless;
-extern crate log;
 extern crate nb;
 #[cfg(feature = "std")]
 extern crate socket2;
@@ -93,6 +92,7 @@ impl AsMut<[UdpTransferId]> for UdpTransferIds {
 pub type UdpTransferId = TransferId64;
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error<S> {
     Memory(OutOfMemoryError),
     Socket(S),

--- a/canadensis_udp/src/rx.rs
+++ b/canadensis_udp/src/rx.rs
@@ -93,7 +93,7 @@ where
                         .handle_frame(&header, bytes_after_header, frame_time)
                         .map_err(Error::Memory);
                 } else {
-                    log::trace!("No matching subject subscription");
+                    l0g::trace!("No matching subject subscription");
                 }
             }
             DataSpecifier::ServiceRequest { service, .. } => {
@@ -104,7 +104,7 @@ where
                         .handle_frame(&header, bytes_after_header, frame_time)
                         .map_err(Error::Memory);
                 } else {
-                    log::trace!("No matching service request subscription");
+                    l0g::trace!("No matching service request subscription");
                 }
             }
             DataSpecifier::ServiceResponse { service, .. } => {
@@ -115,7 +115,7 @@ where
                         .handle_frame(&header, bytes_after_header, frame_time)
                         .map_err(Error::Memory);
                 } else {
-                    log::trace!("No matching service response subscription");
+                    l0g::trace!("No matching service response subscription");
                 }
             }
         }
@@ -356,8 +356,9 @@ where
                 )))
             }
             Ok(None) => Ok(None),
+            #[allow(unused_variables)]
             Err(e) => {
-                log::warn!("Buildup error {:?}, removing session", e);
+                l0g::warn!("Buildup error {:?}, removing session", e);
                 self.sessions.remove(source_node_id);
                 Ok(None)
             }
@@ -407,6 +408,7 @@ where
 }
 
 #[derive(Default, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct UdpSessionData {
     buildup: Option<Buildup>,
 }

--- a/canadensis_udp/src/rx/buildup.rs
+++ b/canadensis_udp/src/rx/buildup.rs
@@ -19,6 +19,7 @@ use crate::UdpTransferId;
 /// * Frames have the same priority
 ///
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Buildup {
     /// The transfer bytes (not including UDP frame headers) that have been collected so far,
     /// excluding any bytes after `max_length`
@@ -99,6 +100,7 @@ impl Buildup {
 
 /// Errors that the buildup may produce
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum BuildupError {
     /// The frame index did not match
     Index,

--- a/canadensis_udp/src/tx.rs
+++ b/canadensis_udp/src/tx.rs
@@ -74,7 +74,7 @@ where
             if frame.deadline > clock.now() {
                 socket.send_to(&frame.data, destination_address)?;
             } else {
-                log::trace!("Discarding outgoing frame because its deadline has passed");
+                l0g::trace!("Discarding outgoing frame because its deadline has passed");
             }
         }
         Ok(())
@@ -172,6 +172,7 @@ where
 }
 
 #[derive(Eq, PartialEq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct UdpFrame {
     deadline: Microseconds32,
     data: Vec<u8>,


### PR DESCRIPTION
This is dependent on unreleased changes in a new dependency crate so it's a draft for now.

The idea here is to avoid pulling in the formatting code from `std` which is massive. 