### PR TITLE
Fix case where `CoreNode` panics on being anonymous

### DIFF
--- a/canadensis/src/lib.rs
+++ b/canadensis/src/lib.rs
@@ -37,7 +37,7 @@ pub mod service;
 use ::core::fmt::{Debug, Formatter};
 use ::core::marker::PhantomData;
 use alloc::vec::Vec;
-use canadensis_core::OutOfMemoryError;
+use canadensis_core::{OutOfMemoryError, ServiceSubscribeError};
 
 use crate::core::transport::Transport;
 use canadensis_core::time::{Clock, MicrosecondDuration32};
@@ -455,7 +455,7 @@ pub trait Node {
         service: ServiceId,
         payload_size_max: usize,
         timeout: MicrosecondDuration32,
-    ) -> Result<(), <Self::Receiver as Receiver<Self::Clock>>::Error>;
+    ) -> Result<(), ServiceSubscribeError<<Self::Receiver as Receiver<Self::Clock>>::Error>>;
 
     /// Unsubscribes from requests for a service
     fn unsubscribe_request(&mut self, service: ServiceId);

--- a/canadensis/src/node/basic.rs
+++ b/canadensis/src/node/basic.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 use canadensis_core::time::{milliseconds, MicrosecondDuration32};
 use canadensis_core::transfer::{MessageTransfer, ServiceTransfer};
 use canadensis_core::transport::{Receiver, Transport};
-use canadensis_core::{nb, Priority, ServiceId, SubjectId};
+use canadensis_core::{nb, Priority, ServiceId, ServiceSubscribeError, SubjectId};
 use canadensis_data_types::uavcan::node::get_info_1_0::{self, GetInfoResponse};
 use canadensis_data_types::uavcan::node::health_1_0::Health;
 use canadensis_data_types::uavcan::node::heartbeat_1_0;
@@ -54,7 +54,7 @@ where
         Self,
         NodeError<
             StartSendError<<N::Transmitter as Transmitter<N::Clock>>::Error>,
-            <N::Receiver as Receiver<N::Clock>>::Error,
+            ServiceSubscribeError<<N::Receiver as Receiver<N::Clock>>::Error>,
         >,
     > {
         // The MinimalNode takes care of heartbeats.
@@ -318,7 +318,7 @@ where
         service: ServiceId,
         payload_size_max: usize,
         timeout: MicrosecondDuration32,
-    ) -> Result<(), <N::Receiver as Receiver<N::Clock>>::Error> {
+    ) -> Result<(), ServiceSubscribeError<<N::Receiver as Receiver<N::Clock>>::Error>> {
         self.node
             .node_mut()
             .subscribe_request(service, payload_size_max, timeout)?;

--- a/canadensis/src/node/core.rs
+++ b/canadensis/src/node/core.rs
@@ -387,15 +387,9 @@ where
         service: ServiceId,
         payload_size_max: usize,
         timeout: MicrosecondDuration32,
-    ) -> Result<(), U::Error> {
-        let status =
-            self.receiver
-                .subscribe_request(service, payload_size_max, timeout, &mut self.driver);
-        // Because a CoreNode can't be anonymous, the above function can't return an Anonymous error.
-        status.map_err(|e| match e {
-            ServiceSubscribeError::Transport(e) => e,
-            ServiceSubscribeError::Anonymous => unreachable!("CoreNode is never anonymous"),
-        })
+    ) -> Result<(), ServiceSubscribeError<U::Error>> {
+        self.receiver
+            .subscribe_request(service, payload_size_max, timeout, &mut self.driver)
     }
 
     fn unsubscribe_request(&mut self, service: ServiceId) {

--- a/canadensis/src/register.rs
+++ b/canadensis/src/register.rs
@@ -4,6 +4,7 @@
 pub mod basic;
 
 use alloc::vec::Vec;
+use canadensis_core::ServiceSubscribeError;
 use core::str;
 
 use crate::{Node, ResponseToken, TransferHandler};
@@ -139,7 +140,7 @@ where
     /// for requests.
     pub fn subscribe_requests<N>(
         node: &mut N,
-    ) -> Result<(), <N::Receiver as Receiver<N::Clock>>::Error>
+    ) -> Result<(), ServiceSubscribeError<<N::Receiver as Receiver<N::Clock>>::Error>>
     where
         N: Node,
     {

--- a/canadensis/src/service/get_info.rs
+++ b/canadensis/src/service/get_info.rs
@@ -1,6 +1,8 @@
 use crate::{Node, ResponseToken, ServiceTransfer, TransferHandler};
 use alloc::vec::Vec;
-use canadensis_core::{time::milliseconds, transport::Receiver};
+use canadensis_core::time::milliseconds;
+use canadensis_core::transport::Receiver;
+use canadensis_core::ServiceSubscribeError;
 use canadensis_data_types::uavcan::node::get_info_1_0::{GetInfoResponse, SERVICE};
 use core::marker::PhantomData;
 
@@ -23,7 +25,7 @@ where
     pub fn new(
         node: &mut N,
         node_info: GetInfoResponse,
-    ) -> Result<Self, <N::Receiver as Receiver<N::Clock>>::Error> {
+    ) -> Result<Self, ServiceSubscribeError<<N::Receiver as Receiver<N::Clock>>::Error>> {
         node.subscribe_request(SERVICE, 0, milliseconds(1000))?;
 
         Ok(Self {


### PR DESCRIPTION
In #37 I missed a case where `CoreNode` will panic if attempting a request subscription on an anonymous node. This PR fixes that.