### PR TITLE
Set no-std for half dependency in dsdl_frontend

### DIFF
--- a/canadensis_dsdl_frontend/Cargo.toml
+++ b/canadensis_dsdl_frontend/Cargo.toml
@@ -14,7 +14,7 @@ num-rational = "0.4"
 num-traits = "0.2"
 unicode-normalization = "0.1.19"
 regex = "1.7.0"
-half = ">=2.2, <2.5"
+half = { ">=2.2, <2.5", default-features = false }
 walkdir = "2.3.2"
 thiserror = "1.0.29"
 once_cell = "1.8.0"


### PR DESCRIPTION
The existing Cargo.toml for canadensis_dsdl_frontend does not disable default-features, which (according to our testing) sets the `std` and `alloc` features in the "half" dependency for the whole project when any crate that depends on canadensis_dsdl_frontend (e.g. canadensis_macro) is included. This precludes those crates from being used on embedded systems that use `#![no_std]`. canadensis_dsdl_frontend is the only crate that doesn't disable default-features and it doesn't actually use `std` or `alloc`, so modifying this just brings it in line with the rest of the crates. 